### PR TITLE
Fix build errors and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Reconciliation
 MSP HUB RECONCILATION TOOL
 \n## CSV Normalization\nThe application now uses `CsvNormalizer` to clean imported CSV files and `ErrorLogger` to store parsing errors.
+\n### Running Tests\nUse `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj`.

--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -20,7 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <ProjectReference Include="../Reconciliation/Reconciliation.csproj" />
-</ItemGroup>
+    <Compile Include="../Reconciliation/CsvNormalizer.cs" Link="CsvNormalizer.cs" />
+    <Compile Include="../Reconciliation/ErrorLogger.cs" Link="ErrorLogger.cs" />
+  </ItemGroup>
 
 </Project>

--- a/Reconciliation/CsvNormalizer.cs
+++ b/Reconciliation/CsvNormalizer.cs
@@ -34,17 +34,17 @@ namespace Reconciliation
                 dt.Rows.Add(row);
             }
 
-            NormalizeDataTable(dt);
+            NormalizeRows(dt);
             return dt.DefaultView;
         }
 
         public static DataView NormalizeDataTable(DataTable table)
         {
-            NormalizeDataTable(table);
+            NormalizeRows(table);
             return table.DefaultView;
         }
 
-        private static void NormalizeDataTable(DataTable table)
+        private static void NormalizeRows(DataTable table)
         {
             int line = 1;
             foreach (DataRow row in table.Rows)
@@ -73,7 +73,7 @@ namespace Reconciliation
                     }
                     else if (IsNumericColumn(column.ColumnName))
                     {
-                        string digits = Regex.Replace(cleaned, "[^0-9\\.\-]", string.Empty);
+                        string digits = Regex.Replace(cleaned, "[^0-9.-]", string.Empty);
                         if (!string.IsNullOrWhiteSpace(digits) && decimal.TryParse(digits, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal num))
                         {
                             row[column] = num.ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
## Summary
- fix project references for test project
- resolve method ambiguity and escape sequence in CsvNormalizer
- document running tests

## Testing
- `dotnet build Reconciliation.Tests/Reconciliation.Tests.csproj -v minimal`
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_683fa2d91b8083278b4703f0b03f3288

## Summary by Sourcery

Fix build errors in CSV normalization by renaming recursive method and correcting regex, update test project configuration, and document running tests

Bug Fixes:
- Rename NormalizeDataTable to NormalizeRows to fix unintended recursion when normalizing data
- Simplify regex pattern in CsvNormalizer to correctly strip non-numeric characters

Documentation:
- Add instructions for running tests to the README

Tests:
- Update Reconciliation.Tests project configuration to fix project references