### PR TITLE
Improve warning and error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 MSP HUB RECONCILATION TOOL
 
 ## CSV Normalization
-The application now uses `CsvNormalizer` to clean imported CSV files and `ErrorLogger` to store parsing errors.
+The application now uses `CsvNormalizer` to clean imported CSV files and `ErrorLogger` to store parsing errors and warnings.
 
 ### Running Tests
 Use `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj`.
 
 ### New Features
 - Fuzzy column matching with optional checkbox in the UI.
-- Human-friendly error logs with timestamps.
+- Human-friendly error and warning logs with timestamps and summaries.
 - Discrepancy detector with numeric/date tolerance and fuzzy text comparison.
 
 ### Discrepancy Detection

--- a/Reconciliation.Tests/CsvNormalizerTests.cs
+++ b/Reconciliation.Tests/CsvNormalizerTests.cs
@@ -10,8 +10,41 @@ namespace Reconciliation.Tests
         public void ErrorLoggerCollectsMessages()
         {
             ErrorLogger.Clear();
-            ErrorLogger.Log("test message");
+            ErrorLogger.LogError("test message");
             Assert.Single(ErrorLogger.Errors);
+        }
+
+        [Fact]
+        public void BlankNumericField_DoesNotLogError()
+        {
+            var table = new DataTable();
+            table.Columns.Add("Quantity");
+            table.Rows.Add("");
+            ErrorLogger.Clear();
+            CsvNormalizer.NormalizeDataTable(table);
+            Assert.Empty(ErrorLogger.Errors);
+        }
+
+        [Fact]
+        public void InvalidNumericField_LogsErrorWithRowInfo()
+        {
+            var table = new DataTable();
+            table.Columns.Add("Quantity");
+            table.Rows.Add("abc");
+            ErrorLogger.Clear();
+            CsvNormalizer.NormalizeDataTable(table);
+            Assert.Single(ErrorLogger.Errors);
+            Assert.Contains("Row 1: The column 'Quantity' expected a numeric value", ErrorLogger.Errors[0]);
+        }
+
+        [Fact]
+        public void SummaryCountsRepeatedErrors()
+        {
+            ErrorLogger.Clear();
+            ErrorLogger.LogError("sample");
+            ErrorLogger.LogError("sample");
+            Assert.True(ErrorLogger.ErrorSummary.TryGetValue("sample", out var count));
+            Assert.Equal(2, count);
         }
     }
 }

--- a/Reconciliation/CsvNormalizer.cs
+++ b/Reconciliation/CsvNormalizer.cs
@@ -57,35 +57,35 @@ namespace Reconciliation
 
                     if (IsDateColumn(column.ColumnName))
                     {
-                        if (!string.IsNullOrWhiteSpace(cleaned) && DateTime.TryParse(cleaned, out DateTime d))
+                        if (string.IsNullOrWhiteSpace(cleaned))
+                        {
+                            row[column] = string.Empty;
+                        }
+                        else if (DateTime.TryParse(cleaned, out DateTime d))
                         {
                             row[column] = d.ToString("yyyy-MM-dd");
                         }
-                        else if (!string.IsNullOrWhiteSpace(cleaned))
-                        {
-                            ErrorLogger.Log($"Line {line}, Field \"{column.ColumnName}\": Value \"{cleaned}\" is not a valid date");
-                            row[column] = cleaned;
-                        }
                         else
                         {
-                            row[column] = string.Empty;
+                            ErrorLogger.LogError($"Row {line}: The column '{column.ColumnName}' expected a date but found '{cleaned}'");
+                            row[column] = cleaned;
                         }
                     }
                     else if (IsNumericColumn(column.ColumnName))
                     {
                         string digits = Regex.Replace(cleaned, "[^0-9.-]", string.Empty);
-                        if (!string.IsNullOrWhiteSpace(digits) && decimal.TryParse(digits, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal num))
+                        if (string.IsNullOrWhiteSpace(cleaned))
+                        {
+                            row[column] = string.Empty;
+                        }
+                        else if (decimal.TryParse(digits, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal num))
                         {
                             row[column] = num.ToString(CultureInfo.InvariantCulture);
                         }
-                        else if (!string.IsNullOrWhiteSpace(cleaned))
-                        {
-                            ErrorLogger.Log($"Line {line}, Field \"{column.ColumnName}\": Value \"{cleaned}\" is not a valid number");
-                            row[column] = cleaned;
-                        }
                         else
                         {
-                            row[column] = string.Empty;
+                            ErrorLogger.LogError($"Row {line}: The column '{column.ColumnName}' expected a numeric value but found '{cleaned}'");
+                            row[column] = cleaned;
                         }
                     }
                     else

--- a/Reconciliation/DataTableExtensions.cs
+++ b/Reconciliation/DataTableExtensions.cs
@@ -18,7 +18,7 @@ namespace Reconciliation
             if (match != null && match != expected)
             {
                 table.Columns[match].ColumnName = expected;
-                ErrorLogger.Log($"Column '{expected}' not found. Using close match '{match}'.");
+                ErrorLogger.LogWarning($"Column '{expected}' was not found. Using close match '{match}'.");
                 return true;
             }
             return table.Columns.Contains(expected);

--- a/Reconciliation/ErrorLogger.cs
+++ b/Reconciliation/ErrorLogger.cs
@@ -1,30 +1,57 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Reconciliation
 {
     public static class ErrorLogger
     {
         private static readonly List<string> _errors = new();
+        private static readonly List<string> _warnings = new();
+
+        private static readonly Dictionary<string, int> _errorCounts = new();
+        private static readonly Dictionary<string, int> _warningCounts = new();
 
         public static IReadOnlyList<string> Errors => _errors.AsReadOnly();
+        public static IReadOnlyList<string> Warnings => _warnings.AsReadOnly();
+
+        public static IReadOnlyDictionary<string, int> ErrorSummary => _errorCounts;
+        public static IReadOnlyDictionary<string, int> WarningSummary => _warningCounts;
 
         public static bool HasErrors => _errors.Count > 0;
+        public static bool HasWarnings => _warnings.Count > 0;
 
-        public static void Log(string message)
+        public static void LogError(string message)
         {
-            string entry = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {message}";
-            lock (_errors)
-            {
-                _errors.Add(entry);
-            }
+            Add(_errors, _errorCounts, message);
+        }
+
+        public static void LogWarning(string message)
+        {
+            Add(_warnings, _warningCounts, message);
         }
 
         public static void LogMissingColumn(string column, string file)
         {
             string msg = $"The expected column '{column}' was not found in the {file} file. Please check your CSV for missing or renamed columns.";
-            Log(msg);
+            LogError(msg);
+        }
+
+        private static void Add(List<string> list, Dictionary<string, int> counts, string message)
+        {
+            string entry = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {message}";
+            lock (list)
+            {
+                list.Add(entry);
+            }
+            lock (counts)
+            {
+                if (counts.ContainsKey(message))
+                    counts[message]++;
+                else
+                    counts[message] = 1;
+            }
         }
 
         public static void Clear()
@@ -32,12 +59,34 @@ namespace Reconciliation
             lock (_errors)
             {
                 _errors.Clear();
+                _errorCounts.Clear();
+            }
+            lock (_warnings)
+            {
+                _warnings.Clear();
+                _warningCounts.Clear();
             }
         }
 
         public static void Export(string filePath)
         {
-            File.WriteAllLines(filePath, _errors);
+            var lines = new List<string>
+            {
+                $"Total Errors: {ErrorSummary.Values.Sum()}, Total Warnings: {WarningSummary.Values.Sum()}",
+                "Type,Message,Count"
+            };
+
+            foreach (var kv in ErrorSummary)
+            {
+                lines.Add($"Error,\"{kv.Key}\",{kv.Value}");
+            }
+
+            foreach (var kv in WarningSummary)
+            {
+                lines.Add($"Warning,\"{kv.Key}\",{kv.Value}");
+            }
+
+            File.WriteAllLines(filePath, lines);
         }
     }
 }


### PR DESCRIPTION
## Summary
- improve structured logging with warnings vs errors
- clean up CSV normalization error messages
- update fuzzy column rename to log a warning
- expand tests for new logging behavior
- document new structured logging in README

## Testing
- `dotnet format --no-restore`
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_683fca299d648327b7101cc3d1596379