### PR TITLE
Fix ErrorLogger references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - Implemented structured error logging with CSV export including row numbers and context.
 - Added DataQualityValidator for comprehensive invoice checks.
+- Updated UI to use new ErrorLogger.Entries collection instead of removed Errors property.

--- a/Reconciliation/Form1.cs
+++ b/Reconciliation/Form1.cs
@@ -466,7 +466,8 @@ namespace Reconciliation
                         dgResultdata.CellFormatting += DgMismatchData_CellFormatting;
                 if (ErrorLogger.HasErrors)
                 {
-                    var res = MessageBox.Show($"Parsing errors found: {ErrorLogger.Errors.Count}. Export log?", "Parsing Errors", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                    var errorCount = ErrorLogger.Entries.Count(e => e.ErrorLevel == "Error");
+                    var res = MessageBox.Show($"Parsing errors found: {errorCount}. Export log?", "Parsing Errors", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                     if (res == DialogResult.Yes)
                     {
                         using var sfd = new SaveFileDialog { Filter = "CSV File|*.csv", FileName = $"ErrorLog_{DateTime.Now:yyyyMMdd_HHmmss}.csv" };


### PR DESCRIPTION
## Summary
- fix UI dialog to count errors using `ErrorLogger.Entries`
- document change in changelog

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release`
- `black . --check`
- `ruff check .`
- `isort . --check-only`


------
https://chatgpt.com/codex/tasks/task_e_68409bea485c8327a0db07346addb6ea

## Summary by Sourcery

Fix UI error counting to use the new ErrorLogger.Entries API and update the changelog accordingly.

Bug Fixes:
- Use ErrorLogger.Entries to compute the parsing error count in the dialog instead of the removed Errors property

Documentation:
- Update CHANGELOG to reference the switch from Errors to Entries for error logging