### PR TITLE
Add schema validation for invoices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Implemented structured error logging with CSV export including row numbers and context.
 - Added DataQualityValidator for comprehensive invoice checks.
 - Updated UI to use new ErrorLogger.Entries collection instead of removed Errors property.
+- Enforced required schema columns for Microsoft and MSP Hub invoices.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ MSP HUB RECONCILATION TOOL
 ## CSV Normalization
 The application now uses `CsvNormalizer` to clean imported CSV files and `ErrorLogger` to store parsing errors and warnings. Validation errors are exported as structured CSV files for easy review.
 
+### Required Columns
+Both invoice types are validated after import. Missing columns abort the run and are logged.
+
+- **Microsoft invoice** must include: `CustomerDomainName`, `ProductId`, `SkuId`, `ChargeType`, `TermAndBillingCycle`.
+- **MSP Hub invoice** must include: `InternalReferenceId`, `SkuId`, `BillingCycle`.
+
+Sample templates are available under `samples/`.
+
 ### Running Tests
 Use `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj`.
 

--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -25,6 +25,8 @@
     <Compile Include="../Reconciliation/FuzzyMatcher.cs" Link="FuzzyMatcher.cs" />
     <Compile Include="../Reconciliation/DiscrepancyDetector.cs" Link="DiscrepancyDetector.cs" />
     <Compile Include="../Reconciliation/DataQualityValidator.cs" Link="DataQualityValidator.cs" />
+    <Compile Include="../Reconciliation/DataTableExtensions.cs" Link="DataTableExtensions.cs" />
+    <Compile Include="../Reconciliation/SchemaValidator.cs" Link="SchemaValidator.cs" />
   </ItemGroup>
 
 </Project>

--- a/Reconciliation.Tests/SchemaValidatorTests.cs
+++ b/Reconciliation.Tests/SchemaValidatorTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Data;
+using Reconciliation;
+
+namespace Reconciliation.Tests
+{
+    public class SchemaValidatorTests
+    {
+        [Fact]
+        public void RequireColumns_ThrowsAndLogs_WhenMissing()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("A");
+            ErrorLogger.Clear();
+            Assert.Throws<ArgumentException>(() => SchemaValidator.RequireColumns(dt, "file.csv", new[] { "A", "B" }, false));
+            Assert.Contains(ErrorLogger.Entries, e => e.ColumnName == "B" && e.FileName == "file.csv");
+        }
+
+        [Fact]
+        public void RequireColumns_FuzzyRenamesColumn()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("ProdutId");
+            SchemaValidator.RequireColumns(dt, "file.csv", new[] { "ProductId" }, true);
+            Assert.Contains("ProductId", dt.Columns.Cast<DataColumn>().Select(c => c.ColumnName));
+        }
+    }
+}

--- a/Reconciliation/SchemaValidator.cs
+++ b/Reconciliation/SchemaValidator.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Reconciliation
+{
+    public static class SchemaValidator
+    {
+        public static void RequireColumns(DataTable table, string fileName, IEnumerable<string> required, bool allowFuzzy)
+        {
+            if (table == null) throw new ArgumentNullException(nameof(table));
+            if (required == null) throw new ArgumentNullException(nameof(required));
+
+            foreach (var column in required)
+            {
+                if (table.Columns.Contains(column))
+                    continue;
+
+                if (allowFuzzy && table.TryFuzzyRenameColumn(column))
+                    continue;
+
+                ErrorLogger.LogMissingColumn(column, fileName);
+                throw new ArgumentException($"The expected column '{column}' is missing from the {fileName} file.");
+            }
+        }
+    }
+}

--- a/samples/MSPHubInvoiceTemplate.csv
+++ b/samples/MSPHubInvoiceTemplate.csv
@@ -1,0 +1,1 @@
+CustomerName,CustomerDomainName,ProductId,SkuId,ChargeType,BillingCycle,InternalReferenceId

--- a/samples/MicrosoftInvoiceTemplate.csv
+++ b/samples/MicrosoftInvoiceTemplate.csv
@@ -1,0 +1,1 @@
+CustomerName,CustomerDomainName,ProductId,SkuId,ChargeType,TermAndBillingCycle,BillingFrequency


### PR DESCRIPTION
## Summary
- add SchemaValidator with required column checks
- test schema validation behaviour
- validate required columns and empty files when importing
- document required columns and provide CSV templates

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -nologo -v q`

------
https://chatgpt.com/codex/tasks/task_e_6840f55600948327bdec66f57c5c30dd