### PR TITLE
Add flexible column auto-mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Added DataQualityValidator for comprehensive invoice checks.
 - Updated UI to use new ErrorLogger.Entries collection instead of removed Errors property.
 - Enforced required schema columns for Microsoft and MSP Hub invoices.
+- Flexible schema validation now auto-maps common column variants (e.g. `SkuName` to `SkuId`) and suggests alternatives when a column is missing.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ MSP HUB RECONCILATION TOOL
 The application now uses `CsvNormalizer` to clean imported CSV files and `ErrorLogger` to store parsing errors and warnings. Validation errors are exported as structured CSV files for easy review.
 
 ### Required Columns
-Both invoice types are validated after import. Missing columns abort the run and are logged.
+Both invoice types are validated after import. Missing columns are automatically
+matched against common variations and renamed when possible. Blocking errors are
+only shown if no suitable column can be mapped.
 
 - **Microsoft invoice** must include: `CustomerDomainName`, `ProductId`, `SkuId`, `ChargeType`, `TermAndBillingCycle`.
 - **MSP Hub invoice** must include: `InternalReferenceId`, `SkuId`, `BillingCycle`.
@@ -15,8 +17,9 @@ Sample templates are available under `samples/`.
 ### Running Tests
 Use `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj`.
 
-### New Features
-- Fuzzy column matching with optional checkbox in the UI.
+- Fuzzy column matching with optional checkbox in the UI. Common variants such
+  as `SkuName`, `SKU` or `sku_id` are automatically mapped to `SkuId` during
+  import.
 - Human-friendly error and warning logs with timestamps and summaries.
 - Discrepancy detector with numeric/date tolerance and fuzzy text comparison.
 

--- a/Reconciliation.Tests/FuzzyMatcherTests.cs
+++ b/Reconciliation.Tests/FuzzyMatcherTests.cs
@@ -20,5 +20,13 @@ namespace Reconciliation.Tests
             var result = FuzzyMatcher.FindClosest("subscription id", options);
             Assert.Equal("SubscriptionId", result);
         }
+
+        [Fact]
+        public void FindClosest_IgnoresUnderscoresAndCase()
+        {
+            var options = new List<string> { "sku_id" };
+            var result = FuzzyMatcher.FindClosest("SkuId", options);
+            Assert.Equal("sku_id", result);
+        }
     }
 }

--- a/Reconciliation.Tests/SchemaValidatorTests.cs
+++ b/Reconciliation.Tests/SchemaValidatorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Collections.Generic;
 using Reconciliation;
 
 namespace Reconciliation.Tests
@@ -23,6 +24,33 @@ namespace Reconciliation.Tests
             dt.Columns.Add("ProdutId");
             SchemaValidator.RequireColumns(dt, "file.csv", new[] { "ProductId" }, true);
             Assert.Contains("ProductId", dt.Columns.Cast<DataColumn>().Select(c => c.ColumnName));
+        }
+
+        public static IEnumerable<object[]> SkuVariants => new List<object[]>
+        {
+            new object[]{"SkuName"},
+            new object[]{"SKU"},
+            new object[]{"sku_id"},
+            new object[]{"Sku"}
+        };
+
+        [Theory]
+        [MemberData(nameof(SkuVariants))]
+        public void RequireColumns_MapsSkuIdVariants(string variant)
+        {
+            var dt = new DataTable();
+            dt.Columns.Add(variant);
+            SchemaValidator.RequireColumns(dt, "file.csv", new[] { "SkuId" }, true);
+            Assert.Contains("SkuId", dt.Columns.Cast<DataColumn>().Select(c => c.ColumnName));
+        }
+
+        [Fact]
+        public void RequireColumns_SuggestsAlternative()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("ProductName");
+            var ex = Assert.Throws<ArgumentException>(() => SchemaValidator.RequireColumns(dt, "file.csv", new[] { "ProductId" }, true));
+            Assert.Contains("Did you mean", ex.Message);
         }
     }
 }

--- a/Reconciliation/DataTableExtensions.cs
+++ b/Reconciliation/DataTableExtensions.cs
@@ -1,10 +1,15 @@
 using System.Data;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Reconciliation
 {
     internal static class DataTableExtensions
     {
+        private static readonly Dictionary<string, string[]> ColumnVariants = new()
+        {
+            ["SkuId"] = ["SkuName", "Sku", "SKU", "sku_id"],
+        };
         /// <summary>
         /// Attempt to rename a column in <paramref name="table"/> to <paramref name="expected"/> using fuzzy matching.
         /// </summary>
@@ -13,16 +18,25 @@ namespace Reconciliation
         /// <returns>True if a column was renamed.</returns>
         public static bool TryFuzzyRenameColumn(this DataTable table, string expected)
         {
-            var options = table.Columns.Cast<DataColumn>().Select(c => c.ColumnName);
-            var match = FuzzyMatcher.FindClosest(expected, options);
+            var options = table.Columns.Cast<DataColumn>().Select(c => c.ColumnName).ToArray();
+            string? match = null;
+
+            if (ColumnVariants.TryGetValue(expected, out var variants))
+            {
+                match = options.FirstOrDefault(o => variants.Any(v => FuzzyMatcher.IsFuzzyMatch(o, v)));
+            }
+
+            match ??= FuzzyMatcher.FindClosest(expected, options);
+
             if (match != null && match != expected)
             {
                 table.Columns[match].ColumnName = expected;
                 ErrorLogger.LogWarning(-1, expected,
-                    $"Column '{expected}' was not found. Using close match '{match}'.",
+                    $"Column '{match}' was mapped to required column '{expected}'.",
                     match, string.Empty, string.Empty);
                 return true;
             }
+
             return table.Columns.Contains(expected);
         }
     }

--- a/Reconciliation/Form1.cs
+++ b/Reconciliation/Form1.cs
@@ -55,7 +55,7 @@ namespace Reconciliation
             _toolTip.SetToolTip(btnCompare, "Run reconciliation using the loaded files");
             _toolTip.SetToolTip(btnExportToCsv, "Export reconciliation results to CSV");
             _toolTip.SetToolTip(btnExportLogs, "Export parsing and processing logs");
-            _toolTip.SetToolTip(chkFuzzyColumns, "Allow approximate column name matches when importing");
+            _toolTip.SetToolTip(chkFuzzyColumns, "Automatically map similar column headers, e.g. 'SkuName' -> 'SkuId'");
             this.rbExternal.CheckedChanged += new System.EventHandler(this.RadioButton_CheckedChanged);
             this.rbInternal.CheckedChanged += new System.EventHandler(this.RadioButton_CheckedChanged);
             this.rbExternal.Checked = true;
@@ -294,30 +294,6 @@ namespace Reconciliation
                     }
                     DataQualityValidator.Run(_sixDotOneDataView.Table, fileInfo.Name);
                     SchemaValidator.RequireColumns(_sixDotOneDataView.Table, "MSP Hub invoice", _requiredMspHubColumns, AllowFuzzyColumns);
-                    if (!_sixDotOneDataView.Table.Columns.Contains("SkuId"))
-                    {
-                        // Check if the second column name is found
-                        if (_sixDotOneDataView.Table.Columns.Contains("SkuName"))
-                        {
-                            // Rename the column to "test"
-                            _sixDotOneDataView.Table.Columns["SkuName"].ColumnName = "SkuId";
-
-                        }
-                        // Check if the second column name is found
-                        else if (_sixDotOneDataView.Table.Columns.Contains("Sku"))
-                        {
-                            // Rename the column to "test"
-                            _sixDotOneDataView.Table.Columns["Sku"].ColumnName = "SkuId";
-
-                        }
-                        else
-                        {
-                            _sixDotOneDataView.Table.Clear();
-                            ErrorLogger.LogMissingColumn("SkuId", "MSP Hub invoice");
-                            throw new ArgumentException("The expected column 'SkuId' is missing from the MSP Hub invoice CSV.");
-
-                        }
-                    }
                     if (_sixDotOneDataView != null && _sixDotOneDataView.Table.Columns.Contains("SkuId"))
                     {
                         foreach (DataRowView rowView in _sixDotOneDataView)

--- a/Reconciliation/FuzzyMatcher.cs
+++ b/Reconciliation/FuzzyMatcher.cs
@@ -72,7 +72,7 @@ namespace Reconciliation
         {
             return new string(input
                 .ToLowerInvariant()
-                .Where(c => !char.IsWhiteSpace(c))
+                .Where(char.IsLetterOrDigit)
                 .ToArray());
         }
     }

--- a/Reconciliation/SchemaValidator.cs
+++ b/Reconciliation/SchemaValidator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 
 namespace Reconciliation
 {
@@ -19,8 +20,13 @@ namespace Reconciliation
                 if (allowFuzzy && table.TryFuzzyRenameColumn(column))
                     continue;
 
+                var options = table.Columns.Cast<DataColumn>().Select(c => c.ColumnName);
+                var suggestion = FuzzyMatcher.FindClosest(column, options, 4);
                 ErrorLogger.LogMissingColumn(column, fileName);
-                throw new ArgumentException($"The expected column '{column}' is missing from the {fileName} file.");
+                var message = $"The expected column '{column}' is missing from the {fileName} file.";
+                if (suggestion != null)
+                    message += $" Did you mean '{suggestion}'?";
+                throw new ArgumentException(message);
             }
         }
     }


### PR DESCRIPTION
## Summary
- support auto mapping of common column variants
- log mapped column names and suggest alternatives
- test fuzzy matching for `SkuId` variants
- update tooltips and docs about column auto mapping

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6840f89f5d24832789cb7ffb6064330e