### PR TITLE
Finalize error log deduplication and context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@
 - Enforced required schema columns for Microsoft and MSP Hub invoices.
 - Flexible schema validation now auto-maps common column variants (e.g. `SkuName` to `SkuId`) and suggests alternatives when a column is missing.
 - Validation tolerances now loaded from `appsettings.json` and expanded fuzzy column mapping.
+- Error log deduplication with configurable summary rows.
+- Raw value logging now captures only the offending cell content.
+- Context values always include customer and SKU or `(missing)` placeholders.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Start the application and select two invoice CSV files. Sample files live under 
 Reconciliation.exe microsoft.csv msphub.csv
 ```
 
-Adjust tolerances in `Reconciliation/appsettings.json` if default numeric or date thresholds do not match your workflow.
+Adjust tolerances in `Reconciliation/appsettings.json` if default numeric or date thresholds do not match your workflow. The `Logging` section controls the number of detailed error rows kept before a summary line is written.
 
 ## CSV Normalization
 The application now uses `CsvNormalizer` to clean imported CSV files and `ErrorLogger` to store parsing errors and warnings. Validation errors are exported as structured CSV files for easy review.

--- a/Reconciliation.Tests/ContextAccuracyTests.cs
+++ b/Reconciliation.Tests/ContextAccuracyTests.cs
@@ -1,0 +1,27 @@
+using Reconciliation;
+using System.Data;
+using System.Linq;
+
+namespace Reconciliation.Tests
+{
+    public class ContextAccuracyTests
+    {
+        [Fact]
+        public void ContextShowsMissingValues()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("CustomerName");
+            dt.Columns.Add("SkuId");
+            dt.Columns.Add("OrderDate");
+            dt.Columns.Add("Quantity");
+            dt.Rows.Add("", "", "bad", "1");
+
+            ErrorLogger.Clear();
+            DataQualityValidator.Run(dt, "file.csv");
+
+            var entry = ErrorLogger.Entries.First();
+            Assert.Contains("Customer: (missing)", entry.Context);
+            Assert.Contains("SKU: (missing)", entry.Context);
+        }
+    }
+}

--- a/Reconciliation.Tests/ErrorLoggerDedupTests.cs
+++ b/Reconciliation.Tests/ErrorLoggerDedupTests.cs
@@ -1,0 +1,25 @@
+using Reconciliation;
+using System.IO;
+using System.Linq;
+
+namespace Reconciliation.Tests
+{
+    public class ErrorLoggerDedupTests
+    {
+        [Fact]
+        public void LogsSummaryAfterThreshold()
+        {
+            ErrorLogger.Clear();
+            ErrorLogger.MaxDetailedRows = 2;
+            for (int i = 0; i < 5; i++)
+            {
+                ErrorLogger.LogError(i + 1, "Col", "Issue", "bad", "f.csv", "ctx");
+            }
+
+            Assert.Equal(3, ErrorLogger.Entries.Count);
+            var summary = ErrorLogger.Entries.Last();
+            Assert.True(summary.IsSummary);
+            Assert.Contains("3 additional rows", summary.Description);
+        }
+    }
+}

--- a/Reconciliation/DataQualityValidator.cs
+++ b/Reconciliation/DataQualityValidator.cs
@@ -97,7 +97,7 @@ namespace Reconciliation
                         if (val < 0)
                         {
                             ErrorLogger.LogWarning(rowIndex, c.ColumnName,
-                                "Negative total value", val.ToString(CultureInfo.InvariantCulture),
+                                "Negative total value", raw,
                                 fileName, ctx);
                         }
                     }
@@ -164,9 +164,10 @@ namespace Reconciliation
 
         private static string GetValue(DataRow row, string column)
         {
-            return row.Table.Columns.Contains(column)
-                ? Convert.ToString(row[column]) ?? string.Empty
-                : string.Empty;
+            if (!row.Table.Columns.Contains(column))
+                return "(missing)";
+            string value = Convert.ToString(row[column]) ?? string.Empty;
+            return string.IsNullOrWhiteSpace(value) ? "(missing)" : value;
         }
     }
 }

--- a/Reconciliation/appsettings.json
+++ b/Reconciliation/appsettings.json
@@ -4,5 +4,8 @@
     "DateToleranceDays": 0,
     "TextDistance": 2,
     "BlankThreshold": 0.1
+  },
+  "Logging": {
+    "MaxDetailedRows": 5
   }
 }


### PR DESCRIPTION
## Summary
- add tests for log deduplication and missing context
- support logging config in `appsettings.json`
- summarize repetitive errors with "Summary" rows
- preserve original raw values and show missing customer/SKU
- document logging options

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release -v q`

------
https://chatgpt.com/codex/tasks/task_e_68410558d9108327b385138d4f693e8e