### PR TITLE
Refactor import logic into service

### DIFF
--- a/Reconciliation.Tests/FileImportServiceTests.cs
+++ b/Reconciliation.Tests/FileImportServiceTests.cs
@@ -1,0 +1,36 @@
+using Reconciliation;
+using System.Data;
+using System.IO;
+
+namespace Reconciliation.Tests
+{
+    public class FileImportServiceTests
+    {
+        [Fact]
+        public void ImportMicrosoftInvoice_FiltersAndSplits()
+        {
+            var path = Path.Combine("TestData", "microsoft.csv");
+            var service = new FileImportService(false);
+            ErrorLogger.Clear();
+            var view = service.ImportMicrosoftInvoice(path);
+            Assert.Single(view);
+            DataRow row = view.Table.Rows[0];
+            Assert.Equal("Annual", row["Term"]);
+            Assert.Equal("Monthly", row["BillingCycle"]);
+        }
+
+        [Fact]
+        public void ImportSixDotOneInvoice_Normalizes()
+        {
+            var path = Path.Combine("TestData", "sixdotone.csv");
+            var service = new FileImportService(true);
+            ErrorLogger.Clear();
+            var view = service.ImportSixDotOneInvoice(path);
+            Assert.Single(view);
+            DataRow row = view.Table.Rows[0];
+            Assert.Equal("2", row["SkuId"]);
+            Assert.True(view.Table.Columns.Contains("BillingCycle"));
+            Assert.False(view.Table.Columns.Contains("BillingFrequency"));
+        }
+    }
+}

--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="../Reconciliation/DataQualityValidator.cs" Link="DataQualityValidator.cs" />
     <Compile Include="../Reconciliation/DataTableExtensions.cs" Link="DataTableExtensions.cs" />
     <Compile Include="../Reconciliation/SchemaValidator.cs" Link="SchemaValidator.cs" />
+    <Compile Include="../Reconciliation/FileImportService.cs" Link="FileImportService.cs" />
     <None Include="TestData\*.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Reconciliation.Tests/TestData/microsoft.csv
+++ b/Reconciliation.Tests/TestData/microsoft.csv
@@ -1,0 +1,3 @@
+CustomerName,CustomerDomainName,ProductId,SkuId,ChargeType,TermAndBillingCycle,BillingFrequency,SubscriptionDescription
+CustomerA,customerA.com,prod1,sku1,Usage,One-Year commitment for monthly/yearly billing,Monthly,Azure plan
+CustomerB,customerB.com,prod2,sku2,Usage,One-Year commitment for monthly/yearly billing,Monthly,Service

--- a/Reconciliation.Tests/TestData/sixdotone.csv
+++ b/Reconciliation.Tests/TestData/sixdotone.csv
@@ -1,0 +1,3 @@
+SkuId,BillingCycle,ResourceName,ValidFrom,ValidTo,PurchaseDate,PartnerTotal,InternalReferenceId,CustomerName,CustomerDomainName,ProductId,ChargeType
+001,Monthly,Azure plan,2024-01-01,2024-01-31,2024-01-01,100,REF1,Client,client.com,prod1,Usage
+002,Monthly,Regular Product,2024-02-01,2024-02-28,2024-02-01,200,REF2,Client,client.com,prod2,Usage

--- a/Reconciliation/FileImportService.cs
+++ b/Reconciliation/FileImportService.cs
@@ -1,0 +1,196 @@
+using System.Data;
+using System.IO;
+using System.Linq;
+
+namespace Reconciliation
+{
+    /// <summary>
+    /// Provides helper methods to import and normalize invoice CSV files.
+    /// </summary>
+    public class FileImportService
+    {
+        private readonly bool _allowFuzzyColumns;
+        private readonly string[] _uniqueKeyColumns =
+        {
+            "CustomerDomainName", "ProductId", "SkuId", "ChargeType", "Term", "BillingCycle"
+        };
+        private readonly string[] _requiredMicrosoftColumns =
+        {
+            "CustomerDomainName", "ProductId", "SkuId", "ChargeType", "TermAndBillingCycle"
+        };
+        private readonly string[] _requiredMspHubColumns =
+        {
+            "InternalReferenceId", "SkuId", "BillingCycle"
+        };
+
+        public FileImportService(bool allowFuzzyColumns)
+        {
+            _allowFuzzyColumns = allowFuzzyColumns;
+        }
+
+        /// <summary>
+        /// Import a Microsoft invoice CSV file.
+        /// </summary>
+        /// <param name="filePath">Path to the CSV file.</param>
+        /// <returns>Normalized DataView.</returns>
+        public DataView ImportMicrosoftInvoice(string filePath)
+        {
+            var fileInfo = new FileInfo(filePath);
+            var dataView = CsvNormalizer.NormalizeCsv(fileInfo.FullName);
+            if (dataView.Table.Rows.Count == 0)
+            {
+                ErrorLogger.LogError(-1, "-", "File is empty", string.Empty, fileInfo.Name, string.Empty);
+                throw new ArgumentException("The selected file contains no rows.");
+            }
+            DataQualityValidator.Run(dataView.Table, fileInfo.Name);
+            SchemaValidator.RequireColumns(dataView.Table, "Microsoft invoice", _requiredMicrosoftColumns, _allowFuzzyColumns);
+
+            for (int i = dataView.Count - 1; i >= 0; i--)
+            {
+                var row = dataView[i].Row;
+                if (SafeGetString(row, "SubscriptionDescription") == "Azure plan")
+                {
+                    dataView.Delete(i);
+                }
+            }
+
+            if (!dataView.Table.Columns.Contains("Term") || !dataView.Table.Columns.Contains("BillingCycle"))
+            {
+                SplitColumn(dataView.Table, "TermAndBillingCycle", "Term", "BillingCycle");
+            }
+
+            dataView = ReorderColumns(dataView.Table, _uniqueKeyColumns.Concat(new[] { "TermAndBillingCycle", "BillingFrequency" }).ToArray());
+            return dataView;
+        }
+
+        /// <summary>
+        /// Import an MSP Hub invoice CSV file.
+        /// </summary>
+        /// <param name="filePath">Path to the CSV file.</param>
+        /// <returns>Normalized DataView.</returns>
+        public DataView ImportSixDotOneInvoice(string filePath)
+        {
+            var fileInfo = new FileInfo(filePath);
+            var dataView = CsvNormalizer.NormalizeCsv(fileInfo.FullName);
+            if (dataView.Table.Rows.Count == 0)
+            {
+                ErrorLogger.LogError(-1, "-", "File is empty", string.Empty, fileInfo.Name, string.Empty);
+                throw new ArgumentException("The selected file contains no rows.");
+            }
+            DataQualityValidator.Run(dataView.Table, fileInfo.Name);
+            SchemaValidator.RequireColumns(dataView.Table, "MSP Hub invoice", _requiredMspHubColumns, _allowFuzzyColumns);
+
+            if (dataView.Table.Columns.Contains("SkuId"))
+            {
+                foreach (DataRowView rowView in dataView)
+                {
+                    string skuId = SafeGetString(rowView.Row, "SkuId");
+                    rowView["SkuId"] = skuId.TrimStart('0');
+                }
+            }
+
+            if (dataView.Table.Columns.Contains("BillingFrequency"))
+                dataView.Table.Columns["BillingFrequency"].ColumnName = "BillingCycle";
+            if (dataView.Table.Columns.Contains("ResourceName"))
+                dataView.Table.Columns["ResourceName"].ColumnName = "ProductName";
+
+            for (int i = dataView.Count - 1; i >= 0; i--)
+            {
+                var row = dataView[i].Row;
+                if (SafeGetString(row, "ProductName") == "Azure plan")
+                {
+                    dataView.Delete(i);
+                }
+            }
+
+            if (dataView.Table.Columns.Contains("ValidFrom"))
+                dataView.Table.Columns["ValidFrom"].ColumnName = "ChargeStartDate";
+            if (dataView.Table.Columns.Contains("ValidTo"))
+                dataView.Table.Columns["ValidTo"].ColumnName = "ChargeEndDate";
+            if (dataView.Table.Columns.Contains("PurchaseDate"))
+                dataView.Table.Columns["PurchaseDate"].ColumnName = "OrderDate";
+            if (dataView.Table.Columns.Contains("PartnerTotal"))
+                dataView.Table.Columns["PartnerTotal"].ColumnName = "Total";
+
+            dataView = ReorderColumns(dataView.Table, _uniqueKeyColumns);
+            return dataView;
+        }
+
+        private static DataView ReorderColumns(DataTable table, string[] columnOrder)
+        {
+            DataTable newTable = new();
+            foreach (string columnName in columnOrder)
+            {
+                if (table.Columns.Contains(columnName))
+                    newTable.Columns.Add(columnName, table.Columns[columnName].DataType);
+            }
+            foreach (DataColumn column in table.Columns)
+            {
+                if (!newTable.Columns.Contains(column.ColumnName))
+                    newTable.Columns.Add(column.ColumnName, column.DataType);
+            }
+            foreach (DataRow row in table.Rows)
+            {
+                DataRow newRow = newTable.Rows.Add();
+                foreach (DataColumn column in newTable.Columns)
+                    newRow[column.ColumnName] = row[column.ColumnName];
+            }
+            return newTable.DefaultView;
+        }
+
+        private static void SplitColumn(DataTable dataTable, string sourceColumnName, string termColumnName, string billingCycleColumnName)
+        {
+            dataTable.Columns.Add(termColumnName, typeof(string));
+            dataTable.Columns.Add(billingCycleColumnName, typeof(string));
+            foreach (DataRow row in dataTable.Rows)
+            {
+                string? termAndBillingCycle = row[sourceColumnName]?.ToString();
+                string billingFrequency = row["BillingFrequency"]?.ToString() ?? string.Empty;
+                DetermineTermAndBillingCycle(termAndBillingCycle, billingFrequency, out string term, out string billingCycle);
+                row[termColumnName] = term;
+                row[billingCycleColumnName] = billingCycle;
+            }
+        }
+
+        private static void DetermineTermAndBillingCycle(string? termAndBillingCycle, string billingFrequency, out string term, out string billingCycle)
+        {
+            term = "NA";
+            billingCycle = "NA";
+            switch (termAndBillingCycle)
+            {
+                case "One-Year commitment for monthly/yearly billing":
+                    term = "Annual";
+                    billingCycle = string.IsNullOrEmpty(billingFrequency) ? "Annual" : "Monthly";
+                    break;
+                case "One-Month commitment for monthly billing":
+                    term = "Monthly";
+                    billingCycle = "Monthly";
+                    break;
+                case "Three-3 Years commitment for monthly/3 Years/yearly billing":
+                    term = "Triennial";
+                    billingCycle = "Monthly";
+                    break;
+                case "1 Cache Instance Hour":
+                    term = "Monthly";
+                    billingCycle = "Monthly";
+                    break;
+                case "One-Year commitment for yearly billing":
+                    term = "Annual";
+                    billingCycle = "Annual";
+                    break;
+                case null or "":
+                    term = "None";
+                    billingCycle = "OneTime";
+                    break;
+            }
+        }
+
+        private static string SafeGetString(DataRow row, string columnName)
+        {
+            if (row == null || string.IsNullOrWhiteSpace(columnName) || !row.Table.Columns.Contains(columnName))
+                return string.Empty;
+            var val = row[columnName];
+            return val == null || val == DBNull.Value ? string.Empty : val.ToString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- pull file parsing out of `Form1` into new `FileImportService`
- add unit tests covering the service
- wire up service in `Form1`

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684748e4f3ac8327b4a04d78e7ff7212

## Summary by Sourcery

Refactor CSV import logic into a dedicated FileImportService, update Form1 to delegate imports to this service, and add unit tests with supporting test data for invoice imports.

Enhancements:
- Extract inline CSV parsing, validation, and transformation from Form1 into a new FileImportService class
- Update Form1’s Microsoft and MSP Hub import handlers to invoke FileImportService instead of performing import logic directly

Tests:
- Add FileImportServiceTests covering Microsoft invoice filtering and term/billing splitting and MSP Hub invoice normalization

Chores:
- Include sample CSV test data files for service tests