### PR TITLE
Add invoice validation service

### DIFF
--- a/Reconciliation.Tests/InvoiceValidationServiceTests.cs
+++ b/Reconciliation.Tests/InvoiceValidationServiceTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Data;
+using Reconciliation;
+
+namespace Reconciliation.Tests
+{
+    public class InvoiceValidationServiceTests
+    {
+        private static DataTable CreateTable()
+        {
+            string[] cols =
+            {
+                "ChargeStartDate","ChargeEndDate","MSRPPrice","EffectiveDays",
+                "PartnerDiscountPercentage","CustomerDiscountPercentage","Total","CustomerSubtotal"
+            };
+            var dt = new DataTable();
+            foreach (var c in cols) dt.Columns.Add(c);
+            return dt;
+        }
+
+        [Fact]
+        public void ValidateInvoice_NoErrors_ReturnsEmpty()
+        {
+            var dt = CreateTable();
+            dt.Rows.Add("2024-01-01","2024-01-30","4","30","19","5","10","10");
+            var svc = new InvoiceValidationService();
+            var result = svc.ValidateInvoice(dt);
+            Assert.Empty(result.Rows);
+        }
+
+        [Fact]
+        public void ValidateInvoice_EffectiveDaysError()
+        {
+            var dt = CreateTable();
+            dt.Rows.Add("2024-01-01","2024-01-30","4","10","19","5","10","10");
+            var result = new InvoiceValidationService().ValidateInvoice(dt);
+            Assert.Single(result.Rows);
+            Assert.Contains("Mismatch", result.Rows[0]["Eff. Days Validation"].ToString());
+        }
+
+        [Fact]
+        public void ValidateInvoice_PartnerDiscountError()
+        {
+            var dt = CreateTable();
+            dt.Rows.Add("2024-01-01","2024-01-30","6","30","5","5","10","10");
+            var result = new InvoiceValidationService().ValidateInvoice(dt);
+            Assert.Single(result.Rows);
+            Assert.Contains("PartnerDiscountPercentage", result.Rows[0]["Partner Discount Validation"].ToString());
+        }
+
+        [Fact]
+        public void ValidateInvoice_HierarchyError()
+        {
+            var dt = CreateTable();
+            dt.Rows.Add("2024-01-01","2024-01-30","4","30","10","20","10","5");
+            var result = new InvoiceValidationService().ValidateInvoice(dt);
+            Assert.Single(result.Rows);
+            Assert.Contains("less than", result.Rows[0]["Discount Hierarchy Check"].ToString());
+        }
+
+        [Fact]
+        public void ValidateInvoice_PricingConsistencyError()
+        {
+            var dt = CreateTable();
+            dt.Rows.Add("2024-01-01","2024-01-30","4","30","19","5","15","10");
+            var result = new InvoiceValidationService().ValidateInvoice(dt);
+            Assert.Single(result.Rows);
+            Assert.Contains("greater", result.Rows[0]["Pricing Consistency Check"].ToString());
+        }
+
+        [Fact]
+        public void ValidateInvoice_MultipleErrors()
+        {
+            var dt = CreateTable();
+            dt.Rows.Add("2024-01-01","2024-01-31","6","10","5","20","15","10");
+            var result = new InvoiceValidationService().ValidateInvoice(dt);
+            Assert.Single(result.Rows);
+            var row = result.Rows[0];
+            Assert.NotEmpty(row["Eff. Days Validation"].ToString());
+            Assert.NotEmpty(row["Partner Discount Validation"].ToString());
+            Assert.NotEmpty(row["Discount Hierarchy Check"].ToString());
+            Assert.NotEmpty(row["Pricing Consistency Check"].ToString());
+        }
+
+        [Fact]
+        public void ValidateInvoice_MissingColumns_DoesNotThrow()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("ChargeStartDate");
+            dt.Columns.Add("ChargeEndDate");
+            dt.Rows.Add("2024-01-01", "2024-01-30");
+            var svc = new InvoiceValidationService();
+            var result = svc.ValidateInvoice(dt);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void ValidateInvoice_EmptyTable_ReturnsEmpty()
+        {
+            var dt = CreateTable();
+            var result = new InvoiceValidationService().ValidateInvoice(dt);
+            Assert.Empty(result.Rows);
+        }
+    }
+}

--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="../Reconciliation/SchemaValidator.cs" Link="SchemaValidator.cs" />
     <Compile Include="../Reconciliation/ReconciliationService.cs" Link="ReconciliationService.cs" />
     <Compile Include="../Reconciliation/FileImportService.cs" Link="FileImportService.cs" />
+    <Compile Include="../Reconciliation/InvoiceValidationService.cs" Link="InvoiceValidationService.cs" />
     <None Include="TestData\*.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Reconciliation/InvoiceValidationService.cs
+++ b/Reconciliation/InvoiceValidationService.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Data;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+namespace Reconciliation
+{
+    /// <summary>
+    /// Validates MSP Hub invoice records for business rule compliance.
+    /// </summary>
+    public class InvoiceValidationService
+    {
+        /// <summary>
+        /// Validates the given invoice table and returns only invalid rows with
+        /// validation error details appended as columns.
+        /// </summary>
+        /// <param name="msphub">Invoice data to validate.</param>
+        /// <returns>Filtered table containing invalid rows.</returns>
+        public DataTable ValidateInvoice(DataTable msphub)
+        {
+            if (msphub == null)
+                throw new ArgumentNullException(nameof(msphub));
+
+            var stopwatch = Stopwatch.StartNew();
+            EnsureValidationColumns(msphub);
+            var rowsToRemove = new List<DataRow>();
+            int high = 0, low = 0;
+
+            foreach (DataRow row in msphub.Rows)
+            {
+                bool invalid = ValidateRow(msphub, row, ref high, ref low);
+                if (!invalid)
+                    rowsToRemove.Add(row);
+            }
+
+            RemoveValidRows(msphub, rowsToRemove);
+            stopwatch.Stop();
+            return msphub;
+        }
+
+        private static void EnsureValidationColumns(DataTable table)
+        {
+            string[] cols =
+            {
+                "Eff. Days Validation",
+                "Partner Discount Validation",
+                "Discount Hierarchy Check",
+                "Pricing Consistency Check"
+            };
+            foreach (var col in cols)
+            {
+                if (!table.Columns.Contains(col))
+                    table.Columns.Add(col, typeof(string));
+            }
+        }
+
+        private static bool ValidateRow(DataTable table, DataRow row,
+            ref int highPriorityErrors, ref int lowPriorityErrors)
+        {
+            string startDateColumn = table.Columns.Contains("ChargeStartDate")
+                ? "ChargeStartDate" : "ValidFrom";
+            string endDateColumn = table.Columns.Contains("ChargeEndDate")
+                ? "ChargeEndDate" : "ValidTo";
+            string msrpColumn = table.Columns.Contains("MSRP")
+                ? "MSRP" : "MSRPPrice";
+
+            DateTime validFrom = DateTime.TryParse(SafeGetString(row, startDateColumn), out var tmpFrom)
+                ? tmpFrom : DateTime.MinValue;
+            DateTime validTo = DateTime.TryParse(SafeGetString(row, endDateColumn), out var tmpTo)
+                ? tmpTo : DateTime.MinValue;
+
+            int effectiveDays = int.TryParse(SafeGetString(row, "EffectiveDays"), out var ed) ? ed : 0;
+            int calculatedDays = (validTo.Date - validFrom.Date).Days + 1;
+
+            decimal msrpPrice = SafeConvertToDecimal(SafeGetString(row, msrpColumn));
+            decimal partnerDiscountPercentage = SafeConvertToDecimal(SafeGetString(row, "PartnerDiscountPercentage"));
+            decimal customerDiscountPercentage = SafeConvertToDecimal(SafeGetString(row, "CustomerDiscountPercentage"));
+            decimal partnerTotal = SafeConvertToDecimal(SafeGetString(row, "Total"));
+            decimal customerSubtotal = SafeConvertToDecimal(SafeGetString(row, "CustomerSubtotal"));
+
+            bool isInvalid = false;
+
+            if (calculatedDays != effectiveDays)
+            {
+                row["Eff. Days Validation"] = $"Mismatch: Expected EffectiveDays is {calculatedDays} days, but found {effectiveDays} days.";
+                isInvalid = true;
+                highPriorityErrors++;
+            }
+
+            if (msrpPrice > 5)
+            {
+                const decimal minDiscount = 18.00m;
+                const decimal maxDiscount = 20.00m;
+                if (partnerDiscountPercentage <= 0)
+                {
+                    row["Partner Discount Validation"] = $"Invalid: MSRP ({msrpPrice}) is greater than 5, but PartnerDiscountPercentage is {partnerDiscountPercentage}%.";
+                    isInvalid = true;
+                    highPriorityErrors++;
+                }
+                else if (partnerDiscountPercentage < minDiscount || partnerDiscountPercentage > maxDiscount)
+                {
+                    row["Partner Discount Validation"] = $"Invalid: PartnerDiscountPercentage ({partnerDiscountPercentage:F2}%) is not between {minDiscount:F2}% and {maxDiscount:F2}%.";
+                    isInvalid = true;
+                    highPriorityErrors++;
+                }
+            }
+
+            if (partnerDiscountPercentage < customerDiscountPercentage)
+            {
+                row["Discount Hierarchy Check"] = $"Invalid: PartnerDiscountPercentage ({partnerDiscountPercentage}%) is less than CustomerDiscountPercentage ({customerDiscountPercentage}%).";
+                isInvalid = true;
+                lowPriorityErrors++;
+            }
+
+            if (Math.Abs(partnerTotal) > Math.Abs(customerSubtotal))
+            {
+                row["Pricing Consistency Check"] = $"Invalid: PartnerTotal ({partnerTotal}) is greater than CustomerSubTotal ({customerSubtotal}).";
+                isInvalid = true;
+                lowPriorityErrors++;
+            }
+
+            return isInvalid;
+        }
+
+        private static void RemoveValidRows(DataTable table, List<DataRow> rows)
+        {
+            foreach (var row in rows)
+                table.Rows.Remove(row);
+        }
+
+        internal static decimal SafeConvertToDecimal(object? value)
+        {
+            if (value == null || value == DBNull.Value) return 0m;
+            return decimal.TryParse(Convert.ToString(value), out var d) ? d : 0m;
+        }
+
+        internal static string SafeGetString(DataRow row, string columnName)
+        {
+            if (row == null || string.IsNullOrWhiteSpace(columnName) || !row.Table.Columns.Contains(columnName))
+                return string.Empty;
+            var val = row[columnName];
+            return val == null || val == DBNull.Value ? string.Empty : val.ToString();
+        }
+
+        internal static string FormatElapsedTime(TimeSpan elapsed)
+        {
+            return elapsed.TotalSeconds < 1
+                ? $"{elapsed.TotalMilliseconds:F2} ms"
+                : elapsed.ToString(@"hh\:mm\:ss");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract invoice validation logic from Form1 into new `InvoiceValidationService`
- add unit tests for invoice validation scenarios
- wire up service inside `Form1`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68475211ed6c83278bdd8fd08d77be68