### PR TITLE
Add PriceMismatchService and refactor Form1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 - Raw value logging now captures only the offending cell content.
 - Context values always include customer and SKU or `(missing)` placeholders.
 - Extracted comparison logic into `ReconciliationService` with dedicated tests.
+- Added `PriceMismatchService` for price difference detection and Excel export.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ the detector instance.
 can be unit tested without the WinForms UI. Use
 `CompareInvoices(msphub, microsoft)` to get a table of discrepancies.
 
+`PriceMismatchService` detects unit price differences between the two invoices
+and can export the mismatches to Excel.
+
 Example summary output:
 
 ```
@@ -56,3 +59,5 @@ each discrepancy.
 
 ## Advanced usage
 Use the **Export** menu to save error logs or comparison results. Add additional fuzzy column variants by editing `DataTableExtensions.ColumnVariants`.
+
+

--- a/Reconciliation.Tests/PriceMismatchServiceTests.cs
+++ b/Reconciliation.Tests/PriceMismatchServiceTests.cs
@@ -1,0 +1,47 @@
+using System.Data;
+using System.IO;
+using OfficeOpenXml;
+
+namespace Reconciliation.Tests
+{
+    public class PriceMismatchServiceTests
+    {
+        [Fact]
+        public void GetPriceMismatches_NoDifferences_ReturnsEmpty()
+        {
+            var svc = new PriceMismatchService();
+            var hub = new DataTable();
+            hub.Columns.Add("CustomerDomainName");
+            hub.Columns.Add("ProductId");
+            hub.Columns.Add("SkuId");
+            hub.Columns.Add("ChargeType");
+            hub.Columns.Add("Term");
+            hub.Columns.Add("BillingCycle");
+            hub.Columns.Add("EffectiveUnitPrice", typeof(decimal));
+            hub.Columns.Add("Quantity", typeof(decimal));
+            hub.Columns.Add("ProductName");
+            hub.Rows.Add("a.com","p1","1","Usage","T","M",1m,1m,"X");
+
+            var ms = hub.Clone();
+            ms.Columns.Add("SubscriptionDescription");
+            ms.Rows.Add("a.com","p1","1","Usage","T","M",1m,1m,"X","X");
+            var result = svc.GetPriceMismatches(hub, ms);
+            Assert.Empty(result.Rows);
+        }
+
+        [Fact]
+        public void ExportPriceMismatchesToExcel_WritesFile()
+        {
+            var svc = new PriceMismatchService();
+            var table = new DataTable();
+            table.Columns.Add("SkuId");
+            table.Columns.Add("PriceInMicrosoft", typeof(decimal));
+            table.Columns.Add("PriceDifference", typeof(decimal));
+            table.Rows.Add("1", 10m, 1m);
+            var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".xlsx");
+            svc.ExportPriceMismatchesToExcel(table, path);
+            using var package = new ExcelPackage(new FileInfo(path));
+            Assert.Equal("SkuId", package.Workbook.Worksheets[0].Cells[1, 1].Text);
+        }
+    }
+}

--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="EPPlus" Version="7.6.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -35,6 +36,7 @@
     <Compile Include="../Reconciliation/ReconciliationService.cs" Link="ReconciliationService.cs" />
     <Compile Include="../Reconciliation/FileImportService.cs" Link="FileImportService.cs" />
     <Compile Include="../Reconciliation/InvoiceValidationService.cs" Link="InvoiceValidationService.cs" />
+    <Compile Include="../Reconciliation/PriceMismatchService.cs" Link="PriceMismatchService.cs" />
     <None Include="TestData\*.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Reconciliation/PriceMismatchService.cs
+++ b/Reconciliation/PriceMismatchService.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Data;
+using System.Linq;
+using System.Drawing;
+using OfficeOpenXml;
+using OfficeOpenXml.Style;
+
+namespace Reconciliation
+{
+    /// <summary>
+    /// Provides price mismatch detection and Excel export functionality.
+    /// </summary>
+    public class PriceMismatchService
+    {
+        private readonly string[] _keyColumns =
+        [
+            "CustomerDomainName",
+            "ProductId",
+            "SkuId",
+            "ChargeType",
+            "Term",
+            "BillingCycle"
+        ];
+
+        /// <summary>
+        /// Returns rows where total price differs between MSP Hub and Microsoft invoices.
+        /// </summary>
+        public DataTable GetPriceMismatches(DataTable msphub, DataTable microsoft)
+        {
+            if (msphub == null) throw new ArgumentNullException(nameof(msphub));
+            if (microsoft == null) throw new ArgumentNullException(nameof(microsoft));
+
+            var filteredHub = msphub.AsEnumerable()
+                .Where(r => !string.Equals(r["ProductName"].ToString(), "Azure plan", StringComparison.OrdinalIgnoreCase))
+                .CopyToDataTable();
+            var filteredMs = microsoft.AsEnumerable()
+                .Where(r => !string.Equals(r["SubscriptionDescription"].ToString(), "Azure plan", StringComparison.OrdinalIgnoreCase))
+                .CopyToDataTable();
+
+            DataTable result = msphub.Clone();
+            result.Columns.Add("PriceInSixDotOne", typeof(decimal));
+            result.Columns.Add("PriceInMicrosoft", typeof(decimal));
+            result.Columns.Add("PriceDifference", typeof(decimal));
+
+            var groupedHub = filteredHub.AsEnumerable()
+                .GroupBy(row => string.Join("|", _keyColumns.Select(c => row[c])));
+            var groupedMs = filteredMs.AsEnumerable()
+                .GroupBy(row => string.Join("|", _keyColumns.Select(c => row[c])));
+
+            foreach (var hubGroup in groupedHub)
+            {
+                var msGroup = groupedMs.FirstOrDefault(g => g.Key == hubGroup.Key);
+                if (msGroup == null) continue;
+
+                decimal qtyHub = hubGroup.Sum(r => SafeDecimal(r["Quantity"]));
+                decimal priceHub = hubGroup.Sum(r => SafeDecimal(r["EffectiveUnitPrice"]) * SafeDecimal(r["Quantity"]));
+                decimal priceMs = msGroup.Sum(r => SafeDecimal(r["EffectiveUnitPrice"]) * SafeDecimal(r["Quantity"]));
+                decimal diff = priceHub - priceMs;
+                if (diff == 0) continue;
+
+                DataRow row = result.NewRow();
+                var keys = hubGroup.Key.Split('|');
+                for (int i = 0; i < _keyColumns.Length; i++)
+                    row[_keyColumns[i]] = keys[i];
+                foreach (DataColumn col in filteredHub.Columns)
+                {
+                    if (_keyColumns.Contains(col.ColumnName) || col.ColumnName == "Quantity")
+                        continue;
+                    row[col.ColumnName] = hubGroup.First()[col];
+                }
+                row["Quantity"] = qtyHub;
+                row["PriceInSixDotOne"] = priceHub;
+                row["PriceInMicrosoft"] = priceMs;
+                row["PriceDifference"] = diff;
+                result.Rows.Add(row);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Exports mismatched rows to an Excel file with colored headers.
+        /// </summary>
+        public void ExportPriceMismatchesToExcel(DataTable mismatches, string filePath)
+        {
+            if (mismatches == null) throw new ArgumentNullException(nameof(mismatches));
+            if (filePath == null) throw new ArgumentNullException(nameof(filePath));
+
+            using var package = new ExcelPackage();
+            ExcelWorksheet ws = package.Workbook.Worksheets.Add("Sheet1");
+            AddHeaderRow(mismatches, ws);
+            AddDataRowsWithColor(mismatches, ws);
+            package.SaveAs(new System.IO.FileInfo(filePath));
+        }
+
+        private static decimal SafeDecimal(object? value)
+        {
+            if (value == null || value == DBNull.Value) return 0m;
+            return Convert.ToDecimal(value);
+        }
+
+        private static void AddHeaderRow(DataTable table, ExcelWorksheet ws)
+        {
+            for (int col = 0; col < table.Columns.Count; col++)
+            {
+                var header = ws.Cells[1, col + 1];
+                header.Value = table.Columns[col].ColumnName;
+                header.Style.Fill.PatternType = ExcelFillStyle.Solid;
+                header.Style.Fill.BackgroundColor.SetColor(ColorTranslator.FromHtml("#D9EAF7"));
+                header.Style.Font.Bold = true;
+                header.Style.Border.Top.Style = ExcelBorderStyle.Thin;
+                header.Style.Border.Bottom.Style = ExcelBorderStyle.Thin;
+                header.Style.Border.Left.Style = ExcelBorderStyle.Thin;
+                header.Style.Border.Right.Style = ExcelBorderStyle.Thin;
+                header.Style.Border.Top.Color.SetColor(Color.Black);
+                header.Style.Border.Bottom.Color.SetColor(Color.Black);
+                header.Style.Border.Left.Color.SetColor(Color.Black);
+                header.Style.Border.Right.Color.SetColor(Color.Black);
+            }
+        }
+
+        private static void AddDataRowsWithColor(DataTable table, ExcelWorksheet ws)
+        {
+            for (int r = 0; r < table.Rows.Count; r++)
+            {
+                for (int c = 0; c < table.Columns.Count; c++)
+                {
+                    var cell = ws.Cells[r + 2, c + 1];
+                    cell.Value = table.Rows[r][c];
+                    cell.Style.Border.Top.Style = ExcelBorderStyle.Thin;
+                    cell.Style.Border.Bottom.Style = ExcelBorderStyle.Thin;
+                    cell.Style.Border.Left.Style = ExcelBorderStyle.Thin;
+                    cell.Style.Border.Right.Style = ExcelBorderStyle.Thin;
+                    cell.Style.Border.Top.Color.SetColor(Color.Black);
+                    cell.Style.Border.Bottom.Color.SetColor(Color.Black);
+                    cell.Style.Border.Left.Color.SetColor(Color.Black);
+                    cell.Style.Border.Right.Color.SetColor(Color.Black);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PriceMismatchService` to compute unit price differences and export them to Excel
- unit test the new service
- use `PriceMismatchService` from the WinForms UI
- document the service and update changelog

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68475a8be2048327adf064d2523198a8

## Summary by Sourcery

Introduce PriceMismatchService to centralize price mismatch detection and Excel exporting, refactor Form1 to use the new service, add corresponding unit tests, and update documentation and changelog.

New Features:
- Add PriceMismatchService for unit price mismatch detection and Excel export
- Integrate PriceMismatchService into the WinForms UI for comparison and export

Enhancements:
- Remove inline FindPriceMismatchedRows logic from Form1 and delegate to PriceMismatchService

Documentation:
- Document PriceMismatchService usage in README
- Add PriceMismatchService entry to CHANGELOG

Tests:
- Add unit tests for PriceMismatchService’s GetPriceMismatches and ExportPriceMismatchesToExcel