### PR TITLE
Ensure Reason column exists in mismatch result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Context values always include customer and SKU or `(missing)` placeholders.
 - Extracted comparison logic into `ReconciliationService` with dedicated tests.
 - Added `PriceMismatchService` for price difference detection and Excel export.
+- Fixed crash when highlighting results with missing "Reason" column by always creating it and skipping highlight when absent.

--- a/Reconciliation/Form1.cs
+++ b/Reconciliation/Form1.cs
@@ -1571,39 +1571,41 @@ namespace Reconciliation
 
         private void DataGridView1_RowPrePaint(object sender, DataGridViewRowPrePaintEventArgs e)
         {
-            if (rbExternal.Checked == true)
-            {
-                var row = dgResultdata.Rows[e.RowIndex];
+            if (!rbExternal.Checked)
+                return;
 
-                // Apply yellow background only to the "Reason" column
-                DataGridViewCell reasonCell = row.Cells["Reason"];
-                if (reasonCell != null && reasonCell.Value != null)
+            var row = dgResultdata.Rows[e.RowIndex];
+            if (!row.DataGridView.Columns.Contains("Reason"))
+                return;
+
+            // Apply yellow background only to the "Reason" column
+            DataGridViewCell reasonCell = row.Cells["Reason"];
+            if (reasonCell != null && reasonCell.Value != null)
+            {
+                string reasonValue = reasonCell.Value.ToString();
+                if (!string.IsNullOrEmpty(reasonValue))
                 {
-                    string reasonValue = reasonCell.Value.ToString();
-                    if (!string.IsNullOrEmpty(reasonValue))
+                    if (reasonValue.Contains("This Line Item is missing in Microsoft Invoice") ||
+                        reasonValue.Contains("This Line Item is missing in MSP Hub Invoice"))
                     {
-                        if (reasonValue.Contains("This Line Item is missing in Microsoft Invoice") ||
-                            reasonValue.Contains("This Line Item is missing in MSP Hub Invoice"))
-                        {
-                            // Set only the Reason column to Yellow
-                            reasonCell.Style.BackColor = Color.Yellow;
-                            reasonCell.Style.ForeColor = Color.Black;
-                        }
+                        // Set only the Reason column to Yellow
+                        reasonCell.Style.BackColor = Color.Yellow;
+                        reasonCell.Style.ForeColor = Color.Black;
                     }
                 }
+            }
 
-                // Existing mismatch highlighting logic
-                foreach (DataGridViewCell cell in row.Cells)
+            // Existing mismatch highlighting logic
+            foreach (DataGridViewCell cell in row.Cells)
+            {
+                if (cell.Value != null)
                 {
-                    if (cell.Value != null)
+                    string cellValue = cell.Value.ToString();
+                    if (cellValue.Contains(MismatchValueIdentifier.MicrosoftMarker) ||
+                        cellValue.Contains(MismatchValueIdentifier.SixDotOneMarker))
                     {
-                        string cellValue = cell.Value.ToString();
-                        if (cellValue.Contains(MismatchValueIdentifier.MicrosoftMarker) ||
-                            cellValue.Contains(MismatchValueIdentifier.SixDotOneMarker))
-                        {
-                            row.DefaultCellStyle.BackColor = ColorTranslator.FromHtml("#EEDC5B"); // Yellow for mismatch
-                            return;
-                        }
+                        row.DefaultCellStyle.BackColor = ColorTranslator.FromHtml("#EEDC5B"); // Yellow for mismatch
+                        return;
                     }
                 }
             }

--- a/Reconciliation/ReconciliationService.cs
+++ b/Reconciliation/ReconciliationService.cs
@@ -16,7 +16,10 @@ namespace Reconciliation
 
             var detector = new DiscrepancyDetector();
             detector.Compare(sixDotOne, microsoft);
-            return detector.GetMismatches();
+            var table = detector.GetMismatches();
+            if (!table.Columns.Contains("Reason"))
+                table.Columns.Add("Reason", typeof(string));
+            return table;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a Reason column in `ReconciliationService.CompareInvoices`
- skip row highlighting when the column is missing
- document the fix in the changelog

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68531b89fc888327839f5d928d5e5e7f