### PR TITLE
Fix fuzzy import & validation rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@
 - Extracted comparison logic into `ReconciliationService` with dedicated tests.
 - Added `PriceMismatchService` for price difference detection and Excel export.
 - Fixed crash when highlighting results with missing "Reason" column by always creating it and skipping highlight when absent.
+- MSP Hub import handles `SkuName` column when fuzzy matching is enabled.
+- Partner discount validation rounds to one decimal place to allow 20.0–20.1%.
+- Results no longer auto-switch to the Logs tab; the tab header flashes instead.
+- Numeric formatter extracted and applied to discrepancy values.

--- a/Reconciliation.Tests/FileImportServiceTests.cs
+++ b/Reconciliation.Tests/FileImportServiceTests.cs
@@ -32,5 +32,16 @@ namespace Reconciliation.Tests
             Assert.True(view.Table.Columns.Contains("BillingCycle"));
             Assert.False(view.Table.Columns.Contains("BillingFrequency"));
         }
+
+        [Fact]
+        public void ImportSixDotOneInvoice_FuzzySkuNameMapped()
+        {
+            var path = Path.Combine("TestData", "sixdotone_skuname.csv");
+            var service = new FileImportService(true);
+            ErrorLogger.Clear();
+            var view = service.ImportSixDotOneInvoice(path);
+            Assert.Single(view);
+            Assert.Contains("SkuId", view.Table.Columns.Cast<DataColumn>().Select(c => c.ColumnName));
+        }
     }
 }

--- a/Reconciliation.Tests/InvoiceValidationServiceTests.cs
+++ b/Reconciliation.Tests/InvoiceValidationServiceTests.cs
@@ -49,6 +49,15 @@ namespace Reconciliation.Tests
         }
 
         [Fact]
+        public void ValidateInvoice_PartnerDiscount205_Passes()
+        {
+            var dt = CreateTable();
+            dt.Rows.Add("2024-01-01","2024-01-30","6","30","20.05","5","10","10");
+            var result = new InvoiceValidationService().ValidateInvoice(dt);
+            Assert.Empty(result.Rows);
+        }
+
+        [Fact]
         public void ValidateInvoice_HierarchyError()
         {
             var dt = CreateTable();

--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -37,7 +37,7 @@
     <Compile Include="../Reconciliation/FileImportService.cs" Link="FileImportService.cs" />
     <Compile Include="../Reconciliation/InvoiceValidationService.cs" Link="InvoiceValidationService.cs" />
     <Compile Include="../Reconciliation/PriceMismatchService.cs" Link="PriceMismatchService.cs" />
-    <Compile Include="../Reconciliation/FormatHelper.cs" Link="FormatHelper.cs" />
+    <Compile Include="../Reconciliation/NumericFormatter.cs" Link="NumericFormatter.cs" />
     <None Include="TestData\*.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Reconciliation.Tests/TestData/sixdotone_skuname.csv
+++ b/Reconciliation.Tests/TestData/sixdotone_skuname.csv
@@ -1,0 +1,2 @@
+SkuName,BillingCycle,ResourceName,ValidFrom,ValidTo,PurchaseDate,PartnerTotal,InternalReferenceId,CustomerName,CustomerDomainName,ProductId,ChargeType
+SKU_1,Monthly,Regular Product,2024-02-01,2024-02-28,2024-02-01,200,REF2,Client,client.com,prod2,Usage

--- a/Reconciliation/DiscrepancyDetector.cs
+++ b/Reconciliation/DiscrepancyDetector.cs
@@ -101,8 +101,8 @@ namespace Reconciliation
                 decimal.TryParse(b, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal db))
             {
                 bool percent = column.Contains("Percent", StringComparison.OrdinalIgnoreCase);
-                string left = percent ? FormatHelper.FormatPercent(da) : FormatHelper.FormatMoney(da);
-                string right = percent ? FormatHelper.FormatPercent(db) : FormatHelper.FormatMoney(db);
+                string left = percent ? NumericFormatter.FormatPercent(da) : NumericFormatter.FormatMoney(da);
+                string right = percent ? NumericFormatter.FormatPercent(db) : NumericFormatter.FormatMoney(db);
                 return $"Numeric mismatch in {column}: {left} vs {right}";
             }
             if (DateTime.TryParse(a, out DateTime ta) && DateTime.TryParse(b, out DateTime tb))
@@ -125,7 +125,7 @@ namespace Reconciliation
             if (decimal.TryParse(value.TrimEnd('%'), NumberStyles.Any, CultureInfo.InvariantCulture, out var d))
             {
                 bool percent = column.Contains("Percent", StringComparison.OrdinalIgnoreCase) || value.Trim().EndsWith("%");
-                string formatted = percent ? FormatHelper.FormatPercent(d) : FormatHelper.FormatMoney(d);
+                string formatted = percent ? NumericFormatter.FormatPercent(d) : NumericFormatter.FormatMoney(d);
                 return percent && value.Trim().EndsWith("%") ? formatted + "%" : formatted;
             }
             return value;

--- a/Reconciliation/FileImportService.cs
+++ b/Reconciliation/FileImportService.cs
@@ -78,6 +78,11 @@ namespace Reconciliation
                 throw new ArgumentException("The selected file contains no rows.");
             }
             DataQualityValidator.Run(dataView.Table, fileInfo.Name);
+            if (_allowFuzzyColumns)
+            {
+                foreach (var col in _requiredMspHubColumns)
+                    dataView.Table.TryFuzzyRenameColumn(col);
+            }
             SchemaValidator.RequireColumns(dataView.Table, "MSP Hub invoice", _requiredMspHubColumns, _allowFuzzyColumns);
 
             if (dataView.Table.Columns.Contains("SkuId"))

--- a/Reconciliation/Form1.cs
+++ b/Reconciliation/Form1.cs
@@ -26,6 +26,7 @@ namespace Reconciliation
         private bool isSwitchingMode = false;
         private bool AllowFuzzyColumns => chkFuzzyColumns.Checked;
         private readonly ToolTip _toolTip = new();
+        private readonly Timer _logFlashTimer = new();
 
         #region Form_UX
 
@@ -74,6 +75,13 @@ namespace Reconciliation
             {
                 tbcMenu.TabPages.Remove(tabPage3);
             }
+
+            _logFlashTimer.Interval = 5000;
+            _logFlashTimer.Tick += (s, e) =>
+            {
+                tabPage2.ForeColor = SystemColors.ControlText;
+                _logFlashTimer.Stop();
+            };
         }
         private void EnableDoubleBuffering(Control control)
         {
@@ -382,7 +390,7 @@ namespace Reconciliation
                 }
 
                 PopulateLogsGrid();
-                tbcMenu.SelectedTab = tabPage2;
+                FlashLogsTab();
             }
             catch (Exception exception)
             {
@@ -1125,6 +1133,13 @@ namespace Reconciliation
             }
 
             dgvLogs.DataSource = table;
+        }
+
+        private void FlashLogsTab()
+        {
+            tabPage2.ForeColor = Color.Red;
+            _logFlashTimer.Stop();
+            _logFlashTimer.Start();
         }
         // Helper method to safely convert to decimal
         private decimal SafeConvertToDecimal(object value)

--- a/Reconciliation/InvoiceValidationService.cs
+++ b/Reconciliation/InvoiceValidationService.cs
@@ -89,19 +89,25 @@ namespace Reconciliation
 
             if (msrpPrice > 5)
             {
-                const decimal minDiscount = 18.00m;
-                const decimal maxDiscount = 20.00m;
+                const decimal minDiscount = 18.0m;
+                const decimal maxDiscount = 20.0m;
                 if (partnerDiscountPercentage <= 0)
                 {
                     row["Partner Discount Validation"] = $"Invalid: MSRP ({msrpPrice}) is greater than 5, but PartnerDiscountPercentage is {partnerDiscountPercentage}%.";
                     isInvalid = true;
                     highPriorityErrors++;
                 }
-                else if (partnerDiscountPercentage < minDiscount || partnerDiscountPercentage > maxDiscount)
+                else
                 {
-                    row["Partner Discount Validation"] = $"Invalid: PartnerDiscountPercentage ({partnerDiscountPercentage:F2}%) is not between {minDiscount:F2}% and {maxDiscount:F2}%.";
-                    isInvalid = true;
-                    highPriorityErrors++;
+                    decimal partner = Math.Round(partnerDiscountPercentage, 1);
+                    decimal lower = Math.Round(minDiscount, 1);
+                    decimal upper = Math.Round(maxDiscount, 1);
+                    if (partner < lower - 0.01m || partner > upper + 0.01m)
+                    {
+                        row["Partner Discount Validation"] = $"Invalid: PartnerDiscountPercentage ({partnerDiscountPercentage:F2}%) is not between {minDiscount:F2}% and {maxDiscount:F2}%.";
+                        isInvalid = true;
+                        highPriorityErrors++;
+                    }
                 }
             }
 

--- a/Reconciliation/NumericFormatter.cs
+++ b/Reconciliation/NumericFormatter.cs
@@ -1,0 +1,11 @@
+namespace Reconciliation
+{
+    internal static class NumericFormatter
+    {
+        internal static string FormatMoney(decimal value)
+            => value.ToString("0.##");
+
+        internal static string FormatPercent(decimal value)
+            => value.ToString("0.##");
+    }
+}


### PR DESCRIPTION
## Summary
- handle `SkuName` early when importing MSP Hub invoices
- round partner discount check to one decimal
- flash Logs tab instead of switching automatically
- format mismatch values via `NumericFormatter`
- add tests for fuzzy `SkuName` and discount edge case
- document changes

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release -v minimal` *(fails: .NET SDK 8.0.301 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853290a81bc8327a284befc983620db

## Summary by Sourcery

Handle fuzzy SkuName imports, refine partner discount validation with one-decimal rounding, flash the Logs tab instead of auto-switching, centralize numeric discrepancy formatting, and add tests and documentation for these changes.

New Features:
- Enable fuzzy SkuName mapping during MSP Hub invoice import when fuzzy matching is enabled

Enhancements:
- Round partner discount validation to one decimal place to account for edge cases
- Flash the Logs tab header instead of automatically switching views after comparison
- Use a new NumericFormatter for consistent money and percent formatting in discrepancies

Documentation:
- Update CHANGELOG with import, validation, UI flash, and formatting updates

Tests:
- Add tests for fuzzy SkuName column mapping in import
- Add test to ensure partner discounts just outside whole percentages pass validation