### PR TITLE
Fix Timer reference ambiguity

### DIFF
--- a/Reconciliation/Form1.cs
+++ b/Reconciliation/Form1.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Drawing;
 using System.Windows.Forms;
+using FormsTimer = System.Windows.Forms.Timer;
 
 namespace Reconciliation
 {
@@ -26,7 +27,7 @@ namespace Reconciliation
         private bool isSwitchingMode = false;
         private bool AllowFuzzyColumns => chkFuzzyColumns.Checked;
         private readonly ToolTip _toolTip = new();
-        private readonly Timer _logFlashTimer = new();
+        private readonly FormsTimer _logFlashTimer = new();
 
         #region Form_UX
 


### PR DESCRIPTION
## Summary
- alias `System.Windows.Forms.Timer` as `FormsTimer`
- use `FormsTimer` for logging timer

## Testing
- `dotnet build "Reconciliation Tool.sln" -p:EnableWindowsTargeting=true --no-restore --verbosity minimal`
- `dotnet test "Reconciliation Tool.sln" -p:EnableWindowsTargeting=true --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68532c8d85f4832790e0ce82eb487887

## Summary by Sourcery

Disambiguate the Timer reference in Form1 by aliasing System.Windows.Forms.Timer as FormsTimer and updating the timer declaration to use the alias.

Enhancements:
- Alias System.Windows.Forms.Timer as FormsTimer to avoid namespace ambiguity.
- Update the Form1 _logFlashTimer field to use the new FormsTimer alias.