### PR TITLE
Update .NET SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.117"
+    "version": "8.0.301",
+    "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
## Summary
- update to .NET SDK 8.0.301 with patch roll-forward

## Testing
- `pytest -q`
- `dotnet --version` *(fails: SDK 8.0.301 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853342eb19c8327a01455b9e940ad03