### PR TITLE
Fix Resources namespace usage for Form1

### DIFF
--- a/Reconciliation/Form1.Designer.cs
+++ b/Reconciliation/Form1.Designer.cs
@@ -1,3 +1,4 @@
+using Reconciliation.Properties;
 ﻿namespace Reconciliation
 {
     partial class Form1

--- a/Reconciliation/Properties/Resources.Designer.cs
+++ b/Reconciliation/Properties/Resources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Reconciliation_Tool.Properties {
+namespace Reconciliation.Properties {
     using System;
     
     


### PR DESCRIPTION
## Summary
- fix resources namespace in designer-generated files
- add missing using for `Reconciliation.Properties`

## Testing
- `dotnet build "Reconciliation Tool.sln" -c Release` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853483ff3c08327b2ab772f2b43cc6a

## Summary by Sourcery

Fix resource namespace and add missing using directive to resolve compilation issues in generated designer files.

Bug Fixes:
- Correct Resources namespace from Reconciliation_Tool.Properties to Reconciliation.Properties in Resources.Designer.cs
- Add missing using directive for Reconciliation.Properties in Form1.Designer.cs