### PR TITLE
Fix csproj compile items

### DIFF
--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="../Reconciliation/FileImportService.cs" Link="FileImportService.cs" />
     <Compile Include="../Reconciliation/InvoiceValidationService.cs" Link="InvoiceValidationService.cs" />
     <Compile Include="../Reconciliation/PriceMismatchService.cs" Link="PriceMismatchService.cs" />
+    <Compile Include="../Reconciliation/FriendlyNameMap.cs" Link="FriendlyNameMap.cs" />
     <Compile Include="../Reconciliation/NumericFormatter.cs" Link="NumericFormatter.cs" />
     <None Include="TestData\*.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Reconciliation/Reconciliation.csproj
+++ b/Reconciliation/Reconciliation.csproj
@@ -25,7 +25,6 @@
     <Compile Update="Form1.cs">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="FriendlyNameMap.cs" />
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
## Summary
- remove redundant FriendlyNameMap include in main project
- add FriendlyNameMap.cs to test compile items

## Testing
- `dotnet build Reconciliation.Tests/Reconciliation.Tests.csproj -v minimal`
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -v minimal` *(fails: CompareInvoices_DetectsMissingRows)*

------
https://chatgpt.com/codex/tasks/task_e_6854586f4cdc83279c337a5fa01a7732