### PR TITLE
Remove unsupported placeholder usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Removed ComboBox.PlaceholderText usage and added a selectable "-- Select a Field --" option for compatibility with older WinForms versions.
 - Accountant-friendly reconciliation outputs with mapped field names, grouped summaries and suggested actions.
 - Filter dropdown and tooltips guide accountants; summaries clear on mode switch and exports include top-level summary row.
 - Implemented structured error logging with CSV export including row numbers and context.

--- a/Reconciliation/Form1.Designer.cs
+++ b/Reconciliation/Form1.Designer.cs
@@ -470,18 +470,18 @@ using Reconciliation.Properties;
             //
             cmbFieldFilter.Location = new Point(1200, 260);
             cmbFieldFilter.Name = "cmbFieldFilter";
-            cmbFieldFilter.PlaceholderText = "e.g., Product Code, Invoice Date";
             cmbFieldFilter.Size = new Size(150, 27);
             cmbFieldFilter.TabIndex = 38;
             cmbFieldFilter.DropDownStyle = ComboBoxStyle.DropDown;
             cmbFieldFilter.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
             cmbFieldFilter.AutoCompleteSource = AutoCompleteSource.ListItems;
+            cmbFieldFilter.Items.Add("-- Select a Field --");
+            cmbFieldFilter.SelectedIndex = 0;
             //
             // txtExplanationFilter
             //
             txtExplanationFilter.Location = new Point(1360, 260);
             txtExplanationFilter.Name = "txtExplanationFilter";
-            txtExplanationFilter.PlaceholderText = "e.g., mismatch, missing, date";
             txtExplanationFilter.Size = new Size(200, 27);
             txtExplanationFilter.TabIndex = 39;
             //

--- a/Reconciliation/Form1.cs
+++ b/Reconciliation/Form1.cs
@@ -693,8 +693,12 @@ namespace Reconciliation
         private void PopulateFieldFilterOptions()
         {
             cmbFieldFilter.Items.Clear();
+            cmbFieldFilter.Items.Add("-- Select a Field --");
             if (_resultData == null || !_resultData.Table.Columns.Contains("Field Name"))
+            {
+                cmbFieldFilter.SelectedIndex = 0;
                 return;
+            }
             var fields = _resultData.Table.AsEnumerable()
                 .Select(r => r["Field Name"].ToString())
                 .Where(s => !string.IsNullOrWhiteSpace(s))
@@ -702,6 +706,7 @@ namespace Reconciliation
                 .OrderBy(s => s)
                 .ToArray();
             cmbFieldFilter.Items.AddRange(fields);
+            cmbFieldFilter.SelectedIndex = 0;
         }
 
         #endregion Button_Clicks


### PR DESCRIPTION
## Summary
- remove `PlaceholderText` from ComboBox and TextBox
- add placeholder item selectable by default
- document placeholder fix in changelog

## Testing
- `pytest -q`
- `dotnet test --no-build --verbosity minimal` *(fails: .NET SDK version 8.0.302 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68545fde87848327974316e7fc688100

## Summary by Sourcery

Remove unsupported PlaceholderText usage on WinForms filter controls by introducing a selectable placeholder item and preselecting it by default, and document the change in the changelog.

Enhancements:
- Remove PlaceholderText property usage from ComboBox and TextBox controls.
- Add a default "-- Select a Field --" option to filter dropdowns and preselect it when initializing and after populating items.

Documentation:
- Document removal of placeholder usage and addition of the selectable placeholder in the changelog.