### PR TITLE
Improve discrepancy filters

### DIFF
--- a/Reconciliation/Form1.Designer.cs
+++ b/Reconciliation/Form1.Designer.cs
@@ -495,7 +495,7 @@ using Reconciliation.Properties;
             txtExplanationFilter.Name = "txtExplanationFilter";
             txtExplanationFilter.Size = new Size(200, 27);
             txtExplanationFilter.TabIndex = 40;
-            txtExplanationFilter.PlaceholderText = "Type a keyword (e.g., missing, mismatch, date)";
+            txtExplanationFilter.PlaceholderText = "Type a keyword (e.g., missing, date, mismatch)";
             //
             // dgResultdata
             // 

--- a/Reconciliation/Form1.cs
+++ b/Reconciliation/Form1.cs
@@ -325,17 +325,8 @@ namespace Reconciliation
 
                     Invoke(new Action(() =>
                     {
-                        var mismatchData = _resultData.Table.Clone();
-
-                        foreach (DataRow row in _resultData.Table.Rows)
-                        {
-                            DataRow newRow = mismatchData.NewRow();
-                            newRow.ItemArray = row.ItemArray; // Copy row data
-                            mismatchData.Rows.Add(newRow); // Add row to new DataTable
-                        }
-
-                        // **Prevent Sorting**
-                        BindingSource bindingSource = new BindingSource { DataSource = mismatchData };
+                        // Bind directly to the DataView so RowFilter updates reflect immediately
+                        BindingSource bindingSource = new BindingSource { DataSource = _resultData };
                         dgResultdata.DataSource = bindingSource;
                         AutoFitColumns(dgResultdata);
 
@@ -380,16 +371,8 @@ namespace Reconciliation
 
                     Invoke(new Action(() =>
                     {
-                        var invalidData = _resultData.Table.Clone();
-
-                        foreach (DataRow row in _resultData.Table.Rows)
-                        {
-                            DataRow newRow = invalidData.NewRow();
-                            newRow.ItemArray = row.ItemArray; // Copy row data
-                            invalidData.Rows.Add(newRow); // Add row to new DataTable
-                        }
-
-                        dgResultdata.DataSource = invalidData.DefaultView;
+                        BindingSource bindingSource = new BindingSource { DataSource = _resultData };
+                        dgResultdata.DataSource = bindingSource;
                         AutoFitColumns(dgResultdata);
                         dgResultdata.ClearSelection();
                         btnExportToCsv.Enabled = true;


### PR DESCRIPTION
## Summary
- bind DataGridView directly to DataView so RowFilter works
- tweak placeholder text for explanation filter

## Testing
- `dotnet test -q` *(fails: NETSDK1100 EnableWindowsTargeting)*

------
https://chatgpt.com/codex/tasks/task_e_68546bc1c73c8327bd72f74b240dc1b6

## Summary by Sourcery

Improve discrepancy filters by binding grid views to the DataView for live filtering and updating placeholder text for the explanation filter.

Enhancements:
- Bind DataGridView directly to the DataView of result data to enable RowFilter functionality.
- Adjust placeholder text in the explanation filter textbox to reorder example keywords.