### PR TITLE
Update .NET SDK version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `PriceMismatchService` for price difference detection and Excel export.
 - Fixed crash when highlighting results with missing "Reason" column by always creating it and skipping highlight when absent.
 - MSP Hub import handles `SkuName` column when fuzzy matching is enabled.
+- Updated `global.json` to target .NET SDK 8.0.100 with roll-forward to latest patch.
 - Partner discount validation rounds to one decimal place to allow 20.0–20.1%.
 - Results no longer auto-switch to the Logs tab; the tab header flashes instead.
 - Numeric formatter extracted and applied to discrepancy values.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.117",
+    "version": "8.0.100",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
## Summary
- update `global.json` to require .NET SDK 8.0.100
- document SDK requirement in the changelog

## Testing
- `black . --check`
- `ruff check .`
- `isort --check-only .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859b39a1bf88327b98d6e5c0eabb6b8

## Summary by Sourcery

Require .NET SDK 8.0.100 and update the changelog accordingly.

Build:
- Update global.json to target .NET SDK 8.0.100 with roll-forward to latest patch.

Documentation:
- Document the updated .NET SDK requirement in CHANGELOG.md.