### PR TITLE
Fix NU1201 by aligning Target Frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@
 - Numeric formatter extracted and applied to discrepancy values.
 - Partner discount validation rounds values before comparison and accepts up to 20.1%.
 - Exported logs and grids show money and percentages with at most two decimals.
+- Test project multi-targets `net8.0` and `net8.0-windows` to avoid NU1201 when referencing the UI project.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If any column is missing the import will fail and list the missing names.
 Sample templates are available under `samples/`. Ensure the headers match the following names exactly.
 
 ### Running Tests
-Use `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj`.
+Use `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj` to run tests for both `net8.0` and `net8.0-windows`.
 
 ### Building the WinForms application
 The project now targets `net8.0-windows` and builds `Reconciliation.exe`.

--- a/Reconciliation.Tests/BuildAsWinExeTest.cs
+++ b/Reconciliation.Tests/BuildAsWinExeTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+#if HAS_UI
 
 namespace Reconciliation.Tests
 {
@@ -15,3 +16,4 @@ namespace Reconciliation.Tests
         }
     }
 }
+#endif

--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
+    <UseWindowsForms>false</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -50,7 +51,14 @@
     <None Include="../Reconciliation/column-map.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
     <ProjectReference Include="..\Reconciliation\Reconciliation.csproj" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+    <DefineConstants>$(DefineConstants);HAS_UI</DefineConstants>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- multi-target test project for net8.0 and net8.0-windows
- include UI project only when building the Windows TFM
- wrap BuildAsWinExeTest in `HAS_UI` so it only compiles for Windows builds
- document new test instructions
- add changelog entry

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Debug -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop workload missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b07c91df08327ad90e1adf569965a