### PR TITLE
Fix invoice validation view and test build order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Reconciliation builds as a WinForms executable (`Reconciliation.exe`).
 - Added advanced reconciliation service with composite key grouping and mapping
   via `column-map.json`.
+- Invoice validation exposes `InvalidRowsView` for easier binding and tests now reference the UI project.
 - UI option "Advanced Compare" runs the new engine and shows summary details.
 - Validation results now report counts of high and low priority errors with a filter option.
 - Credit and debit rows with the same customer and SKU are now netted before

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ the detector instance.
 can be unit tested without the WinForms UI. Use
 `CompareInvoices(msphub, microsoft)` to get a table of discrepancies.
 
+### Invoice Validation
+`InvoiceValidationService.ValidateInvoice` now returns an `InvoiceValidationResult`
+with an `InvalidRowsView` property for easy data binding in the UI or tests.
+
 `PriceMismatchService` detects unit price differences between the two invoices
 and can export the mismatches to Excel. Credit lines followed by a matching
 debit are aggregated so prorated adjustments cancel out before comparison.

--- a/Reconciliation Tool.sln
+++ b/Reconciliation Tool.sln
@@ -22,9 +22,12 @@ Global
 		{537EFA54-85BD-4EE4-B9D7-CDF2C72E8589}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{537EFA54-85BD-4EE4-B9D7-CDF2C72E8589}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+        GlobalSection(ProjectDependencies) = postSolution
+                {537EFA54-85BD-4EE4-B9D7-CDF2C72E8589}.{426CBF07-1EC1-26CB-8BBC-771BDB7F006C} = {426CBF07-1EC1-26CB-8BBC-771BDB7F006C}
+        EndGlobalSection
 GlobalSection(ExtensibilityGlobals) = postSolution
                 SolutionGuid = {C1AC0A61-D407-4109-BDA8-77D56E33DF24}
                 StartupProject = Reconciliation

--- a/Reconciliation.Tests/InvoiceValidationResultTests.cs
+++ b/Reconciliation.Tests/InvoiceValidationResultTests.cs
@@ -1,0 +1,18 @@
+using System.Data;
+using Reconciliation;
+using Xunit;
+
+namespace Reconciliation.Tests
+{
+    public class InvoiceValidationResultTests
+    {
+        [Fact]
+        public void InvalidRowsView_ReturnsDataView()
+        {
+            var t = new DataTable();
+            t.Columns.Add("A");
+            var r = new InvoiceValidationResult(t, 0, 0);
+            Assert.Equal(t.DefaultView, r.InvalidRowsView);
+        }
+    }
+}

--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -5,6 +5,7 @@
     <UseWindowsForms>false</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -26,6 +27,9 @@
       <Link>appsettings.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <Compile Include="../Reconciliation/AppConfig.cs" Link="AppConfig.cs" />
     <Compile Include="../Reconciliation/CsvNormalizer.cs" Link="CsvNormalizer.cs" />
     <Compile Include="../Reconciliation/ErrorLogger.cs" Link="ErrorLogger.cs" />
@@ -45,6 +49,7 @@
     <Compile Include="../Reconciliation/DataNormaliser.cs" Link="DataNormaliser.cs" />
     <Compile Include="../Reconciliation/AdvancedReconciliationService.cs" Link="AdvancedReconciliationService.cs" />
     <Compile Include="../Reconciliation/ReconciliationResult.cs" Link="ReconciliationResult.cs" />
+    <Compile Include="../Reconciliation/InvoiceValidationResult.cs" Link="InvoiceValidationResult.cs" />
     <None Include="TestData\*.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -59,6 +64,7 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
     <DefineConstants>$(DefineConstants);HAS_UI</DefineConstants>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
 </Project>

--- a/Reconciliation/Form1.cs
+++ b/Reconciliation/Form1.cs
@@ -415,7 +415,7 @@ namespace Reconciliation
                         var svc = new InvoiceValidationService();
                         return svc.ValidateInvoice(_sixDotOneDataView.Table);
                     });
-                    _resultData = validation.InvalidRows.DefaultView;
+                    _resultData = validation.InvalidRowsView;
                     _lastSummary = $"High: {validation.HighPriority}  Low: {validation.LowPriority}";
 
                     Invoke(new Action(() =>
@@ -1517,25 +1517,18 @@ namespace Reconciliation
                 }
                 else
                 {
-                    _resultData = await Task.Run(() =>
+                    var invalResult = await Task.Run(() =>
                     {
                         var startTime = DateTime.Now; // Capture start time
 
                         // Validate records
-                        var invalidRecordsTable = new InvoiceValidationService().ValidateInvoice(_sixDotOneDataView.Table);
-                        return invalidRecordsTable.DefaultView; // Convert DataTable to DataView
+                        return new InvoiceValidationService().ValidateInvoice(_sixDotOneDataView.Table);
                     });
+                    _resultData = invalResult.InvalidRowsView;
 
                     Invoke(new Action(() =>
                     {
-                        var invalidData = _resultData.Table.Clone();
-
-                        foreach (DataRow row in _resultData.Table.Rows)
-                        {
-                            DataRow newRow = invalidData.NewRow();
-                            newRow.ItemArray = row.ItemArray; // Copy row data
-                            invalidData.Rows.Add(newRow); // Add row to new DataTable
-                        }
+                        var invalidData = invalResult.InvalidRows.Copy();
 
                         dgResultdata.DataSource = invalidData.DefaultView;
                         dgResultdata.ClearSelection();

--- a/Reconciliation/InvoiceValidationResult.cs
+++ b/Reconciliation/InvoiceValidationResult.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Data;
+
+namespace Reconciliation
+{
+    /// <summary>
+    /// Result of invoice validation containing invalid rows and error counts.
+    /// </summary>
+    public class InvoiceValidationResult
+    {
+        public InvoiceValidationResult(DataTable invalidRows, int highPriority, int lowPriority)
+        {
+            InvalidRows = invalidRows ?? throw new ArgumentNullException(nameof(invalidRows));
+            HighPriority = highPriority;
+            LowPriority = lowPriority;
+        }
+
+        /// <summary>
+        /// Table containing invalid invoice rows.
+        /// </summary>
+        public DataTable InvalidRows { get; }
+
+        /// <summary>
+        /// Convenience view over <see cref="InvalidRows"/>.
+        /// </summary>
+        public DataView InvalidRowsView => InvalidRows.DefaultView;
+
+        /// <summary>
+        /// Count of high priority errors.
+        /// </summary>
+        public int HighPriority { get; }
+
+        /// <summary>
+        /// Count of low priority errors.
+        /// </summary>
+        public int LowPriority { get; }
+    }
+}

--- a/Reconciliation/InvoiceValidationService.cs
+++ b/Reconciliation/InvoiceValidationService.cs
@@ -8,7 +8,6 @@ namespace Reconciliation
     /// <summary>
     /// Validates MSP Hub invoice records for business rule compliance.
     /// </summary>
-    public record InvoiceValidationResult(DataTable InvalidRows, int HighPriority, int LowPriority);
 
     public class InvoiceValidationService
     {

--- a/Reconciliation/Reconciliation.csproj
+++ b/Reconciliation/Reconciliation.csproj
@@ -12,6 +12,7 @@
     <FileVersion>4.0.0.8</FileVersion>
     <PublishSingleFile>true</PublishSingleFile>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="7.6.1" />


### PR DESCRIPTION
## Summary
- expose InvalidRowsView on InvoiceValidationResult
- use the new view in Form1
- return InvoiceValidationResult from InvoiceValidationService
- ensure test project references main project and supports Windows targeting
- add unit test for InvalidRowsView
- document changes in README and CHANGELOG

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release -f net8.0 --filter FullyQualifiedName~InvoiceValidationResultTests`


------
https://chatgpt.com/codex/tasks/task_e_685b1fd6f3808327b43f224796046246