### PR TITLE
Fix binding for invalid invoice rows

### DIFF
--- a/Reconciliation/Form1.cs
+++ b/Reconciliation/Form1.cs
@@ -1528,9 +1528,7 @@ namespace Reconciliation
 
                     Invoke(new Action(() =>
                     {
-                        var invalidData = invalResult.InvalidRows.Copy();
-
-                        dgResultdata.DataSource = invalidData.DefaultView;
+                        dgResultdata.DataSource = invalResult.InvalidRowsView;
                         dgResultdata.ClearSelection();
                         btnExportToCsv.Enabled = true;
 


### PR DESCRIPTION
## Summary
- bind InvalidRowsView directly to the results grid

## Testing
- `dotnet build "Reconciliation Tool.sln" -v minimal`
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -v minimal` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d9e15e08327b03f9f296507786d