### PR TITLE
Improve mismatch ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ File.WriteAllText("summary.txt", detector.GetSummary());
 `diff.csv` will contain rows with the left and right values plus a reason for
 each discrepancy.
 
+Discrepancies are ordered by row number and field name in both the on-screen
+table and the exported CSV so the results are easier to scan.
+
 ## Advanced usage
 Use the **Export** menu to save error logs or comparison results.
 The new reconciliation engine loads mapping rules from `column-map.json` and

--- a/Reconciliation.Tests/DiscrepancyOrderingTests.cs
+++ b/Reconciliation.Tests/DiscrepancyOrderingTests.cs
@@ -1,0 +1,29 @@
+using Reconciliation;
+using System.Data;
+
+namespace Reconciliation.Tests
+{
+    public class DiscrepancyOrderingTests
+    {
+        [Fact]
+        public void GetMismatches_ReturnsSortedRows()
+        {
+            var left = new DataTable();
+            left.Columns.Add("A");
+            left.Columns.Add("B");
+            left.Rows.Add("1", "x");
+
+            var right = new DataTable();
+            right.Columns.Add("A");
+            right.Columns.Add("B");
+            right.Rows.Add("2", "y");
+
+            var detector = new DiscrepancyDetector();
+            detector.Compare(left, right);
+            var table = detector.GetMismatches();
+
+            Assert.Equal("A", table.Rows[0]["Field Name"]);
+            Assert.Equal("B", table.Rows[1]["Field Name"]);
+        }
+    }
+}

--- a/Reconciliation/DiscrepancyDetector.cs
+++ b/Reconciliation/DiscrepancyDetector.cs
@@ -140,6 +140,13 @@ namespace Reconciliation
                 _summary[group] = 1;
         }
 
+        private IEnumerable<Discrepancy> OrderedDiscrepancies()
+        {
+            return _discrepancies
+                .OrderBy(d => d.Row)
+                .ThenBy(d => d.Column, StringComparer.OrdinalIgnoreCase);
+        }
+
         private static string FormatValue(string value, string column)
         {
             if (decimal.TryParse(value.TrimEnd('%'), NumberStyles.Any, CultureInfo.InvariantCulture, out var d))
@@ -164,7 +171,7 @@ namespace Reconciliation
             table.Columns.Add("Explanation", typeof(string));
             table.Columns.Add("Suggested Action", typeof(string));
 
-            foreach (var d in _discrepancies)
+            foreach (var d in OrderedDiscrepancies())
             {
                 var row = table.NewRow();
                 string group = GetGroupName(d.Column, d.Explanation);
@@ -206,7 +213,7 @@ namespace Reconciliation
                 $"Summary: {summaryLine}",
                 "Row Number,Field Name,Our Value,Microsoft Value,Explanation,Suggested Action"
             };
-            foreach (var d in _discrepancies)
+            foreach (var d in OrderedDiscrepancies())
             {
                 string left = FormatValue(d.LeftValue, d.Column);
                 string right = FormatValue(d.RightValue, d.Column);


### PR DESCRIPTION
## Summary
- sort discrepancy output by row and column
- document that ordering in the README
- test ordering of mismatches

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj` *(fails: .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c56700bb88331b2137ade8b64ec3a

## Summary by Sourcery

Order discrepancy results by row and field name, update display and export to use the ordering, document the change, and add a test to validate the ordering

Enhancements:
- Sort discrepancy output by row number and field name in both the on-screen table and CSV export

Documentation:
- Document the discrepancy ordering in the README

Tests:
- Add a test to verify that mismatches are returned in the correct sorted order