### PR TITLE
Improve numeric parsing and row discrepancy handling

### DIFF
--- a/Reconciliation.Tests/ReconciliationServiceTests.cs
+++ b/Reconciliation.Tests/ReconciliationServiceTests.cs
@@ -117,5 +117,24 @@ namespace Reconciliation.Tests
             Assert.All(result.Rows.Cast<DataRow>(), r =>
                 Assert.Contains("Hub row", r["Explanation"].ToString()));
         }
+
+        [Fact]
+        public void TryParseMoney_ParsesScientificNotation()
+        {
+            bool ok = ReconciliationService.TryParseMoney("0E-20", out var d);
+            Assert.True(ok);
+            Assert.Equal(0m, d);
+        }
+
+        [Fact]
+        public void BlankTaxTotal_DoesNotLogError()
+        {
+            var table = new DataTable();
+            table.Columns.Add("TaxTotal");
+            table.Rows.Add("");
+            ErrorLogger.Clear();
+            CsvNormalizer.NormalizeDataTable(table);
+            Assert.Empty(ErrorLogger.Entries);
+        }
     }
 }

--- a/Reconciliation/CsvNormalizer.cs
+++ b/Reconciliation/CsvNormalizer.cs
@@ -3,11 +3,16 @@ using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 namespace Reconciliation
 {
     public static class CsvNormalizer
     {
+        private static readonly HashSet<string> NumericColumns = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "UnitPrice", "EffectiveUnitPrice", "Quantity", "Subtotal", "TaxTotal", "Total"
+        };
         public static DataView NormalizeCsv(string filePath)
         {
             using var parser = new TextFieldParser(filePath);
@@ -107,9 +112,7 @@ namespace Reconciliation
 
         private static bool IsNumericColumn(string name)
         {
-            name = name.ToLowerInvariant();
-            string[] hints = { "price", "amount", "quantity", "total", "unit", "rate" };
-            return hints.Any(h => name.Contains(h));
+            return NumericColumns.Contains(name);
         }
 
         private static bool IsDateColumn(string name)

--- a/Reconciliation/ReconciliationService.cs
+++ b/Reconciliation/ReconciliationService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Globalization;
 
 namespace Reconciliation
 {
@@ -102,13 +103,30 @@ namespace Reconciliation
         {
             var r = table.NewRow();
             r["Row Number"] = row;
-            r["Field Name"] = key;
-            r["Our Value"] = string.Empty;
+            r["Field Name"] = "Row";
+            r["Our Value"] = key;
             r["Microsoft Value"] = string.Empty;
             r["Explanation"] = message;
             r["Suggested Action"] = string.Empty;
             r["Reason"] = message;
             table.Rows.Add(r);
+        }
+
+        public static bool TryParseMoney(string s, out decimal d)
+        {
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                d = 0m;
+                return true;
+            }
+            return decimal.TryParse(
+                s,
+                NumberStyles.AllowDecimalPoint |
+                NumberStyles.AllowLeadingSign |
+                NumberStyles.AllowExponent |
+                NumberStyles.AllowTrailingSign,
+                CultureInfo.InvariantCulture,
+                out d);
         }
 
         private static string Key(DataRow row)
@@ -126,7 +144,7 @@ namespace Reconciliation
         {
             a = a.Trim();
             b = b.Trim();
-            if (decimal.TryParse(a, out var da) && decimal.TryParse(b, out var db))
+            if (TryParseMoney(a, out var da) && TryParseMoney(b, out var db))
             {
                 return Math.Abs(da - db) <= AppConfig.Validation.NumericTolerance;
             }


### PR DESCRIPTION
## Summary
- parse monetary values with scientific notation
- restrict numeric columns to true financial fields
- record missing rows with clearer metadata
- add unit tests for `TryParseMoney` and blank `TaxTotal`

## Testing
- `dotnet test -f net8.0 --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685f02222f308331aa9d69529ffd17cb

## Summary by Sourcery

Enhance numeric parsing and row discrepancy reporting, tighten CSV numeric column filtering, and add robust tests for money parsing and blank tax totals.

New Features:
- Add TryParseMoney method to parse monetary values with scientific notation
- Restrict numeric column detection to a fixed set of financial field names

Enhancements:
- Use TryParseMoney for all numeric comparisons with tolerance
- Improve missing-row entries to include row number in metadata fields

Tests:
- Add unit test for TryParseMoney handling scientific notation
- Add unit test to verify blank TaxTotal does not log errors