### PR TITLE
Add business-key reconciliation service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Reconciliation builds as a WinForms executable (`Reconciliation.exe`).
 - Added advanced reconciliation service with composite key grouping and mapping
   via `column-map.json`.
+- Added `BusinessKeyReconciliationService` for strict business-key matching and
+  financial column comparison with tolerance.
 - Improved button labels, tooltips and grid styling in the main UI for clarity.
 - Invoice validation exposes `InvalidRowsView` for easier binding and tests now reference the UI project.
 - UI option "Advanced Compare" runs the new engine and shows summary details.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ tolerances by setting `NumericTolerance`, `DateTolerance` and `TextDistance` on
 the detector instance.
 
 `ReconciliationService` encapsulates the external invoice matching logic so it
-can be unit tested without the WinForms UI. Use
-`CompareInvoices(msphub, microsoft)` to get a table of discrepancies.
+can be unit tested without the WinForms UI.
+`BusinessKeyReconciliationService` provides stricter business-key matching and
+financial comparison. Call `Reconcile(msphub, microsoft)` to get a table of
+discrepancies.
 
 ### Invoice Validation
 `InvoiceValidationService.ValidateInvoice` now returns an `InvoiceValidationResult`

--- a/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
+++ b/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
@@ -1,0 +1,49 @@
+using System.Data;
+using Reconciliation;
+
+namespace Reconciliation.Tests;
+
+public class BusinessKeyReconciliationServiceTests
+{
+    private static DataTable CreateTable()
+    {
+        string[] cols =
+        {
+            "CustomerDomainName","ProductId","ChargeType","ChargeStartDate","SubscriptionId",
+            "UnitPrice","Subtotal","Total","Quantity"
+        };
+        var dt = new DataTable();
+        foreach (var c in cols) dt.Columns.Add(c);
+        return dt;
+    }
+
+    [Fact]
+    public void Reconcile_DetectsMissingRows()
+    {
+        var ours = CreateTable();
+        ours.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
+        var ms = CreateTable();
+
+        var svc = new BusinessKeyReconciliationService();
+        var result = svc.Reconcile(ours, ms);
+
+        Assert.Single(result.Rows);
+        Assert.Equal("Missing in Microsoft", result.Rows[0]["Explanation"]);
+    }
+
+    [Fact]
+    public void Reconcile_DetectsMismatchedTotal()
+    {
+        var ours = CreateTable();
+        ours.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
+        var ms = CreateTable();
+        ms.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","12","1");
+
+        var svc = new BusinessKeyReconciliationService();
+        var result = svc.Reconcile(ours, ms);
+
+        Assert.Single(result.Rows);
+        Assert.Equal("Total", result.Rows[0]["Field Name"]);
+        Assert.Contains("Mismatch in Total", result.Rows[0]["Explanation"].ToString());
+    }
+}

--- a/Reconciliation.Tests/Reconciliation.Tests.csproj
+++ b/Reconciliation.Tests/Reconciliation.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="../Reconciliation/CsvSchemaMapper.cs" Link="CsvSchemaMapper.cs" />
     <Compile Include="../Reconciliation/DataNormaliser.cs" Link="DataNormaliser.cs" />
     <Compile Include="../Reconciliation/AdvancedReconciliationService.cs" Link="AdvancedReconciliationService.cs" />
+    <Compile Include="../Reconciliation/BusinessKeyReconciliationService.cs" Link="BusinessKeyReconciliationService.cs" />
     <Compile Include="../Reconciliation/ReconciliationResult.cs" Link="ReconciliationResult.cs" />
     <Compile Include="../Reconciliation/InvoiceValidationResult.cs" Link="InvoiceValidationResult.cs" />
     <None Include="TestData\*.csv">

--- a/Reconciliation/BusinessKeyReconciliationService.cs
+++ b/Reconciliation/BusinessKeyReconciliationService.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+
+namespace Reconciliation
+{
+    /// <summary>
+    /// Reconciles two invoice tables using a fixed composite business key and
+    /// compares only specified financial columns with tolerance.
+    /// </summary>
+    public class BusinessKeyReconciliationService
+    {
+        private static readonly string[] KeyColumns =
+        {
+            "CustomerDomainName",
+            "ProductId",
+            "ChargeType",
+            "ChargeStartDate",
+            "SubscriptionId"
+        };
+
+        private static readonly string[] FinancialColumns =
+        {
+            "UnitPrice","EffectiveUnitPrice","MSRP","MSRPPrice","Subtotal","TaxTotal","Total","Quantity",
+            "PartnerDiscountPercentage","PartnerDiscount","PartnerSubTotal","PartnerTotal",
+            "CustomerUnitPrice","CustomerEffectiveUnitPrice","CustomerSubTotal","CustomerTotal",
+            "CustomerDiscountPercentage","CustomerDiscount",
+            "EffectiveMSRP","PartnerUnitPrice","PartnerPerDayUnitPrice","CustomerPerDayUnitPrice"
+        };
+
+        /// <summary>Summary text describing how many discrepancies were found.</summary>
+        public string LastSummary { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Compare two invoices and return a table of mismatched fields ordered
+        /// by business key and field name.
+        /// </summary>
+        public DataTable Reconcile(DataTable ours, DataTable microsoft)
+        {
+            if (ours == null) throw new ArgumentNullException(nameof(ours));
+            if (microsoft == null) throw new ArgumentNullException(nameof(microsoft));
+
+            var oursGroups = BuildGroups(ours);
+            var msGroups = BuildGroups(microsoft);
+            var sharedFields = FinancialColumns
+                .Where(f => ours.Columns.Contains(f) && microsoft.Columns.Contains(f))
+                .ToArray();
+
+            var result = BuildResultTable();
+
+            foreach (var key in oursGroups.Keys.Union(msGroups.Keys))
+            {
+                oursGroups.TryGetValue(key, out var oursRows);
+                msGroups.TryGetValue(key, out var msRows);
+                int count = Math.Max(oursRows?.Count ?? 0, msRows?.Count ?? 0);
+                for (int i = 0; i < count; i++)
+                {
+                    DataRow? ourRow = (oursRows != null && i < oursRows.Count) ? oursRows[i] : null;
+                    DataRow? msRow = (msRows != null && i < msRows.Count) ? msRows[i] : null;
+                    if (ourRow == null || msRow == null)
+                    {
+                        AddMissingRow(result, key, ourRow == null ? "Missing in MSPUP" : "Missing in Microsoft");
+                        continue;
+                    }
+                    foreach (var field in sharedFields)
+                    {
+                        var ourVal = Convert.ToString(ourRow[field]) ?? string.Empty;
+                        var msVal = Convert.ToString(msRow[field]) ?? string.Empty;
+                        if (ValuesEqual(ourVal, msVal)) continue;
+                        AddMismatchRow(result, key, field, ourVal, msVal);
+                    }
+                }
+            }
+
+            // Order by composite key then field name
+            var ordered = result.AsEnumerable()
+                .OrderBy(r => r[KeyColumns[0]])
+                .ThenBy(r => r[KeyColumns[1]])
+                .ThenBy(r => r[KeyColumns[2]])
+                .ThenBy(r => r[KeyColumns[3]])
+                .ThenBy(r => r[KeyColumns[4]])
+                .ThenBy(r => r["Field Name"]);
+            var orderedTable = BuildResultTable();
+            foreach (var r in ordered) orderedTable.ImportRow(r);
+
+            LastSummary = $"Discrepancies found: {orderedTable.Rows.Count}";
+            return orderedTable;
+        }
+
+        private static Dictionary<string, List<DataRow>> BuildGroups(DataTable table)
+        {
+            var dict = new Dictionary<string, List<DataRow>>(StringComparer.OrdinalIgnoreCase);
+            foreach (DataRow row in table.Rows)
+            {
+                if (!HasValidKey(row)) continue;
+                string key = BuildKey(row);
+                if (!dict.TryGetValue(key, out var list))
+                {
+                    list = new List<DataRow>();
+                    dict[key] = list;
+                }
+                list.Add(row);
+            }
+            return dict;
+        }
+
+        private static bool HasValidKey(DataRow row)
+        {
+            foreach (var col in KeyColumns)
+            {
+                if (!row.Table.Columns.Contains(col)) return false;
+                string val = Convert.ToString(row[col]) ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(val)) return false;
+            }
+            return true;
+        }
+
+        private static string BuildKey(DataRow row)
+        {
+            return string.Join("|", KeyColumns.Select(c => Convert.ToString(row[c])!.Trim().ToUpperInvariant()));
+        }
+
+        private static DataTable BuildResultTable()
+        {
+            var t = new DataTable();
+            foreach (var c in KeyColumns) t.Columns.Add(c);
+            t.Columns.Add("Field Name");
+            t.Columns.Add("Our Value");
+            t.Columns.Add("Microsoft Value");
+            t.Columns.Add("Explanation");
+            t.Columns.Add("Suggested Action");
+            t.Columns.Add("Reason");
+            return t;
+        }
+
+        private static void AddMissingRow(DataTable table, string key, string message)
+        {
+            var r = table.NewRow();
+            var parts = key.Split('|');
+            for (int i = 0; i < KeyColumns.Length; i++)
+                r[KeyColumns[i]] = i < parts.Length ? parts[i] : string.Empty;
+            r["Field Name"] = "Row";
+            r["Our Value"] = string.Empty;
+            r["Microsoft Value"] = string.Empty;
+            r["Explanation"] = message;
+            r["Suggested Action"] = string.Empty;
+            r["Reason"] = "Row missing in " + (message.Contains("Microsoft") ? "Microsoft invoice" : "MSPUP invoice");
+            table.Rows.Add(r);
+        }
+
+        private static void AddMismatchRow(DataTable table, string key, string field, string ourVal, string msVal)
+        {
+            var r = table.NewRow();
+            var parts = key.Split('|');
+            for (int i = 0; i < KeyColumns.Length; i++)
+                r[KeyColumns[i]] = i < parts.Length ? parts[i] : string.Empty;
+            r["Field Name"] = FriendlyNameMap.Get(field);
+            r["Our Value"] = ourVal;
+            r["Microsoft Value"] = msVal;
+            r["Explanation"] = $"Mismatch in {field}: {ourVal} vs {msVal}";
+            r["Suggested Action"] = string.Empty;
+            r["Reason"] = "Amount mismatch";
+            table.Rows.Add(r);
+        }
+
+        private static bool ValuesEqual(string a, string b)
+        {
+            a = a.Trim();
+            b = b.Trim();
+            if (decimal.TryParse(a, NumberStyles.Any, CultureInfo.InvariantCulture, out var da) &&
+                decimal.TryParse(b, NumberStyles.Any, CultureInfo.InvariantCulture, out var db))
+            {
+                return Math.Abs(da - db) <= AppConfig.Validation.NumericTolerance;
+            }
+            return string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `BusinessKeyReconciliationService` for strict key-based comparisons
- scaffold unit tests for the new service
- document the new engine in README and changelog

## Testing
- `dotnet test --no-build --verbosity quiet` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f39219348327b07ddad2b96c76d9

## Summary by Sourcery

Introduce a new service for strict business-key reconciliation of invoice tables with configurable tolerance, add corresponding unit tests, and update documentation accordingly.

New Features:
- Add BusinessKeyReconciliationService for strict composite business-key invoice matching with tolerance-based financial comparisons.

Documentation:
- Update README and CHANGELOG to document the new BusinessKeyReconciliationService.

Tests:
- Add unit tests for BusinessKeyReconciliationService to detect missing rows and mismatched financial values.