### PR TITLE
Improve business-key reconciliation with alias mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Business-key reconciliation uses alias mapping and logs kid-friendly summary buckets.
 - Updated tests to target only `net8.0` and fixed build on non-Windows hosts.
 - Removed leftover `RowPrePaint` event wiring in `Form1`.
 - Pinned SDK version to `8.0.117` for Linux CI compatibility.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ the detector instance.
 `ReconciliationService` encapsulates the external invoice matching logic so it
 can be unit tested without the WinForms UI.
 `BusinessKeyReconciliationService` provides stricter business-key matching and
-financial comparison.
+financial comparison. Column aliases like `DomainUrl` or `SubscriptionGuid`
+are normalised automatically and the summary logs now show kid-friendly
+counts of perfect matches, missing rows and mismatches.
 
 ```csharp
 var svc = new BusinessKeyReconciliationService(

--- a/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
+++ b/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
@@ -5,11 +5,15 @@ namespace Reconciliation.Tests;
 
 public class BusinessKeyReconciliationServiceTests
 {
-    private static DataTable CreateTable()
+    private static DataTable CreateTable(bool useAliases = false)
     {
         string[] cols =
         {
-            "CustomerDomainName","ProductId","ChargeType","ChargeStartDate","SubscriptionId",
+            useAliases ? "DomainUrl" : "CustomerDomainName",
+            useAliases ? "ProductGuid" : "ProductId",
+            "ChargeType",
+            "ChargeStartDate",
+            useAliases ? "SubscriptionGuid" : "SubscriptionId",
             "UnitPrice","Subtotal","Total","Quantity"
         };
         var dt = new DataTable();
@@ -22,7 +26,7 @@ public class BusinessKeyReconciliationServiceTests
     {
         var ours = CreateTable();
         ours.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
-        var ms = CreateTable();
+        var ms = CreateTable(true);
 
         var svc = new BusinessKeyReconciliationService();
         var result = svc.Reconcile(ours, ms);
@@ -36,7 +40,7 @@ public class BusinessKeyReconciliationServiceTests
     {
         var ours = CreateTable();
         ours.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
-        var ms = CreateTable();
+        var ms = CreateTable(true);
         ms.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","12","1");
 
         var svc = new BusinessKeyReconciliationService();
@@ -52,7 +56,7 @@ public class BusinessKeyReconciliationServiceTests
     {
         var ours = CreateTable();
         ours.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
-        var ms = CreateTable();
+        var ms = CreateTable(true);
         ms.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
 
         var svc = new BusinessKeyReconciliationService();
@@ -66,7 +70,7 @@ public class BusinessKeyReconciliationServiceTests
     {
         var ours = CreateTable();
         ours.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
-        var ms = CreateTable();
+        var ms = CreateTable(true);
         ms.Rows.Add("cust.com","P1","Usage","2024-01-02","SUB1","1","1","10","1");
 
         var svc = new BusinessKeyReconciliationService();
@@ -74,4 +78,19 @@ public class BusinessKeyReconciliationServiceTests
 
         Assert.Empty(result.Rows);
     }
+
+    [Fact]
+    public void BusinessKeyReconciliation_AliasesWork()
+    {
+        var ours = CreateTable();
+        ours.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
+        var ms = CreateTable(true);
+        ms.Rows.Add("cust.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
+
+        var svc = new BusinessKeyReconciliationService();
+        var result = svc.Reconcile(ours, ms);
+
+        Assert.Empty(result.Rows);
+    }
 }
+

--- a/Reconciliation/CsvPreProcessor.cs
+++ b/Reconciliation/CsvPreProcessor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Reconciliation;
@@ -17,6 +18,21 @@ public static class CsvPreProcessor
     {
         if (table == null) throw new ArgumentNullException(nameof(table));
 
+        // Apply header aliases
+        var aliasMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "SubscriptionGuid", "SubscriptionId" },
+            { "DomainUrl", "CustomerDomainName" },
+            { "CustomerName", "CustomerDomainName" },
+            { "CustomerId", "CustomerDomainName" },
+            { "ProductGuid", "ProductId" },
+            { "MPNId", "ProductId" },
+            { "BillableQuantity", "Quantity" }
+        };
+
+        foreach (var kvp in aliasMap)
+            Rename(table, kvp.Key, kvp.Value);
+
         Rename(table, "PartnerUnitPrice", "UnitPrice");
         Rename(table, "PartnerEffectiveUnitPrice", "EffectiveUnitPrice");
         Rename(table, "PartnerTotal", "Total");
@@ -28,6 +44,13 @@ public static class CsvPreProcessor
             if (!table.Columns.Contains(col))
                 table.Columns.Add(col, typeof(string));
         }
+
+        // Normalise key fields (trim, upper, date format)
+        DataNormaliser.Normalise(table, new[]
+        {
+            "CustomerDomainName","ProductId","ChargeType","ChargeStartDate",
+            "SubscriptionId","SubscriptionGuid"
+        });
     }
 
     private static void Rename(DataTable table, string oldName, string newName)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.302",
+    "version": "8.0.117",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
## Summary
- add unit tests for alias mapping
- support header aliases and key normalisation
- track perfect/missing/mismatch counts in summary
- document new behaviour in README and changelog

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68630e888a78832789a60113dc88f20f

## Summary by Sourcery

Introduce header alias mapping and key normalization to the reconciliation workflow, enhance reconciliation summaries with detailed match/mismatch counts, update related tests and documentation, and pin the .NET SDK version.

New Features:
- Support header alias mapping and key normalization in CSV preprocessing
- Track counts of perfect matches, only-in-MSP, only-in-Microsoft, and mismatches in reconciliation summary

Enhancements:
- Fallback to SubscriptionGuid when SubscriptionId is unavailable
- Streamline and reduce financial columns list

Build:
- Pin .NET SDK version to 8.0.117 for cross-platform CI compatibility

Documentation:
- Document alias mapping and kid-friendly summary buckets in README
- Update CHANGELOG with new alias mapping behavior

Tests:
- Add unit test for alias mapping
- Update existing reconciliation tests to use alias-enabled tables