### PR TITLE
Fix tenant casing and log shared-column absence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Tenant slice and alias fixes ensure Microsoft rows are filtered to the MSP tenant and SubscriptionGUID is recognised.
 - Updated tests to target only `net8.0` and fixed build on non-Windows hosts.
 - Removed leftover `RowPrePaint` event wiring in `Form1`.
+- Missing-row detection no longer exits early and tenant filtering ignores case.
 - Pinned SDK version to `8.0.117` for Linux CI compatibility.
 - Reconciliation builds as a WinForms executable (`Reconciliation.exe`).
 - Added advanced reconciliation service with composite key grouping and mapping

--- a/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
+++ b/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
@@ -143,5 +143,21 @@ public class BusinessKeyReconciliationServiceTests
         Assert.Empty(diff.Rows);
         Assert.Equal("Perfect:1 | Only-MSP:0 | Only-MS:0 | Diff:0", svc.LastSummary);
     }
+
+    [Fact]
+    public void TenantFilter_CaseInsensitive()
+    {
+        var ours = CreateTable();
+        ours.Rows.Add("foo.com","P1","Usage","2024-01-01","SUB1","1","1","10","1");
+
+        var ms = CreateTable(true);
+        ms.Rows.Add("FOO.COM","P1","Usage","2024-01-01","SUB1","1","1","10","1");
+
+        var svc = new BusinessKeyReconciliationService();
+        var result = svc.Reconcile(ours, ms);
+
+        Assert.Empty(result.Rows);
+        Assert.Equal("Perfect:1 | Only-MSP:0 | Only-MS:0 | Diff:0", svc.LastSummary);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add case-insensitive tenant filter test
- log when no shared finance columns found and use invariant case for tenant filter
- note fix in changelog

## Testing
- `black . --check`
- `ruff check .`
- `isort --check-only .`
- `dotnet test -c Release --no-build` *(fails: .NET SDK 8.0.302 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864327c0f9083279bfa45376d666df6

## Summary by Sourcery

Fix tenant filter to use invariant case comparison and log when no shared finance columns are present

Bug Fixes:
- Make tenant filtering case-insensitive to match domains regardless of casing

Enhancements:
- Log an informational message when no shared finance columns are found

Documentation:
- Update changelog to note missing-row detection change and case-insensitive tenant filtering

Tests:
- Add a test for case-insensitive tenant filtering