### PR TITLE
Update reconciliation for generic MSPHub partners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Missing-row detection no longer exits early and tenant filtering ignores case.
 - Pinned SDK version to `8.0.117` for Linux CI compatibility.
 - Reconciliation builds as a WinForms executable (`Reconciliation.exe`).
+- Business key reconciliation now works for any MSPHub partner invoice and only
+  flags rows missing in Microsoft; extra Microsoft lines are ignored.
 - Added `ValueParser.SafeDecimal` utility and updated services to use it.
 - Row matching now uses only `CustomerDomainName` and `ProductId` so missing columns no longer skip rows.
 - Added advanced reconciliation service with composite key grouping and mapping

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ can be unit tested without the WinForms UI.
 `BusinessKeyReconciliationService` provides stricter business-key matching and
 financial comparison. Column aliases like `DomainUrl` or `SubscriptionGuid`
 are normalised automatically and the summary logs now show kid-friendly
-counts of perfect matches, missing rows and mismatches.
+counts of perfect matches, missing rows and mismatches. Rows that appear only
+in the Microsoft invoice are ignored so the tool works for any MSPHub partner.
 
 ```csharp
 var svc = new BusinessKeyReconciliationService();

--- a/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
+++ b/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
@@ -117,7 +117,7 @@ public class BusinessKeyReconciliationServiceTests
         var result = svc.Reconcile(ours, ms);
 
         Assert.Empty(result.Rows);
-        Assert.Equal("Perfect:1 | Only-MSP:0 | Only-MS:0 | Diff:0", svc.LastSummary);
+        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class BusinessKeyReconciliationServiceTests
         var diff = svc.Reconcile(ours, ms);
 
         Assert.Empty(diff.Rows);
-        Assert.Equal("Perfect:1 | Only-MSP:0 | Only-MS:0 | Diff:0", svc.LastSummary);
+        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class BusinessKeyReconciliationServiceTests
         var result = svc.Reconcile(ours, ms);
 
         Assert.Empty(result.Rows);
-        Assert.Equal("Perfect:1 | Only-MSP:0 | Only-MS:0 | Diff:0", svc.LastSummary);
+        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
     }
 
     [Fact]
@@ -167,7 +167,24 @@ public class BusinessKeyReconciliationServiceTests
         var result = svc.Reconcile(ours, ms);
 
         Assert.Empty(result.Rows);
-        Assert.Equal("Perfect:1 | Only-MSP:0 | Only-MS:0 | Diff:0", svc.LastSummary);
+        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
+    }
+
+    [Fact]
+    public void Reconcile_IgnoresRowsOnlyInMicrosoft()
+    {
+        var ours = CreateTable();
+        ours.Rows.Add("cust.com","P1","1","1","10","1");
+
+        var ms = CreateTable(true);
+        ms.Rows.Add("cust.com","P1","1","1","10","1");
+        ms.Rows.Add("cust.com","P2","1","1","10","1"); // extra row only in MS
+
+        var svc = new BusinessKeyReconciliationService();
+        var result = svc.Reconcile(ours, ms);
+
+        Assert.Empty(result.Rows);
+        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
     }
 }
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.302",
+    "version": "8.0.117",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
## Summary
- improve BusinessKeyReconciliationService so extra Microsoft rows are ignored
- adjust tests and add coverage for Microsoft-only rows
- pin dotnet SDK to 8.0.117 for CI compatibility
- document generic partner support in README and changelog

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6865956d215883279326f64bfef5a280