### PR TITLE
Implement simplified reconciliation summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Business-key reconciliation uses alias mapping and logs kid-friendly summary buckets.
+- Business-key reconciliation now reports "Matched", "Missing in Microsoft" and "Mismatched" counts.
 - Tenant slice and alias fixes ensure Microsoft rows are filtered to the MSP tenant and SubscriptionGUID is recognised.
 - Updated tests to target only `net8.0` and fixed build on non-Windows hosts.
 - Removed leftover `RowPrePaint` event wiring in `Form1`.

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ the detector instance.
 
 `ReconciliationService` encapsulates the external invoice matching logic so it
 can be unit tested without the WinForms UI.
-`BusinessKeyReconciliationService` provides stricter business-key matching and
+`BusinessKeyReconciliationService` provides strict business-key matching and
 financial comparison. Column aliases like `DomainUrl` or `SubscriptionGuid`
-are normalised automatically and the summary logs now show kid-friendly
-counts of perfect matches, missing rows and mismatches. Rows that appear only
-in the Microsoft invoice are ignored so the tool works for any MSPHub partner.
+are normalised automatically and the summary logs now show counts of
+matched pairs, rows missing in Microsoft and mismatched totals. Rows that
+appear only in the Microsoft invoice are ignored so the tool works for any
+MSPHub partner.
 
 ```csharp
 var svc = new BusinessKeyReconciliationService();

--- a/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
+++ b/Reconciliation.Tests/BusinessKeyReconciliationServiceTests.cs
@@ -39,7 +39,7 @@ public class BusinessKeyReconciliationServiceTests
         var result = svc.Reconcile(ours, ms);
 
         Assert.Single(result.Rows);
-        Assert.Equal("Missing in Microsoft", result.Rows[0]["Explanation"]);
+        Assert.Equal("Missing in Microsoft", result.Rows[0]["Status"]);
     }
 
     [Fact]
@@ -54,8 +54,7 @@ public class BusinessKeyReconciliationServiceTests
         var result = svc.Reconcile(ours, ms);
 
         Assert.Single(result.Rows);
-        Assert.Equal("Total", result.Rows[0]["Field Name"]);
-        Assert.Contains("Mismatch in Total", result.Rows[0]["Explanation"].ToString());
+        Assert.Equal("Mismatched", result.Rows[0]["Status"]);
     }
 
     [Fact]
@@ -117,7 +116,7 @@ public class BusinessKeyReconciliationServiceTests
         var result = svc.Reconcile(ours, ms);
 
         Assert.Empty(result.Rows);
-        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
+        Assert.Equal("Matched: 1 | Missing in Microsoft: 0 | Mismatched: 0", svc.LastSummary);
     }
 
     [Fact]
@@ -133,7 +132,7 @@ public class BusinessKeyReconciliationServiceTests
         var diff = svc.Reconcile(ours, ms);
 
         Assert.Empty(diff.Rows);
-        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
+        Assert.Equal("Matched: 1 | Missing in Microsoft: 0 | Mismatched: 0", svc.LastSummary);
     }
 
     [Fact]
@@ -149,7 +148,7 @@ public class BusinessKeyReconciliationServiceTests
         var result = svc.Reconcile(ours, ms);
 
         Assert.Empty(result.Rows);
-        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
+        Assert.Equal("Matched: 1 | Missing in Microsoft: 0 | Mismatched: 0", svc.LastSummary);
     }
 
     [Fact]
@@ -167,7 +166,7 @@ public class BusinessKeyReconciliationServiceTests
         var result = svc.Reconcile(ours, ms);
 
         Assert.Empty(result.Rows);
-        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
+        Assert.Equal("Matched: 1 | Missing in Microsoft: 0 | Mismatched: 0", svc.LastSummary);
     }
 
     [Fact]
@@ -184,7 +183,7 @@ public class BusinessKeyReconciliationServiceTests
         var result = svc.Reconcile(ours, ms);
 
         Assert.Empty(result.Rows);
-        Assert.Equal("Perfect:1 | Missing-MS:0 | Diff:0", svc.LastSummary);
+        Assert.Equal("Matched: 1 | Missing in Microsoft: 0 | Mismatched: 0", svc.LastSummary);
     }
 }
 


### PR DESCRIPTION
## Summary
- refactor business key reconciliation to follow simplified logic
- update results grid to only list customer-product keys with status
- revise summary output and update README/CHANGELOG
- adjust tests for new logic

## Testing
- `dotnet test Reconciliation.Tests/Reconciliation.Tests.csproj -c Release --nologo` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659a67eb3c832788128e9bec007dc5

## Summary by Sourcery

Simplify the reconciliation service by removing domain and tenant filters, condensing mismatch logic, and updating the result table and summary output to use a single Status column with "Matched", "Missing in Microsoft", and "Mismatched" statuses.

Enhancements:
- Streamline reconciliation loop by eliminating tenant/domain filtering and using grouped data directly
- Condense result table to only include CustomerDomainName, ProductId, and a unified Status field
- Unify financial comparison into a simple matched/missing/mismatched classification
- Update LastSummary format to report counts of Matched, Missing in Microsoft, and Mismatched records

Documentation:
- Revise README and CHANGELOG to document the new summary statuses and simplified logic

Tests:
- Adapt tests to assert the new Status column and updated summary string